### PR TITLE
Widget Setup View Keyboard Responsiveness

### DIFF
--- a/Modulite/Screens/Home/Controller/HomeViewController.swift
+++ b/Modulite/Screens/Home/Controller/HomeViewController.swift
@@ -33,6 +33,13 @@ class HomeViewController: UIViewController {
     
     private func setupNavigationBar() {
         // FIXME: Make image be on bottom-left of navbar with large title
+            
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor.screenBackground
+                
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
         
         if let image = UIImage(named: "navbar-app-name") {
             let imageView = UIImageView(image: image)


### PR DESCRIPTION
This Pull Request addresses the issue where the keyboard was obscuring the search bar within the `WidgetSetupView`. To enhance user experience, I have implemented dynamic adjustments to the UIScrollView's content offset based on the keyboard's visibility. This ensures that the search bar remains visible and accessible, even when the keyboard is active.

### Key Changes:
- Added notification observers for keyboard show and hide events.
- Calculated the position of the search bar within its parent view.
- Adjusted the `UIScrollView`'s `frame.origin.y` to ensure the search bar is visible when the keyboard appears.
- Reset the content offset when the keyboard is dismissed to maintain the natural layout of the view.

These improvements should make the Widget Setup View more user-friendly by preventing the keyboard from blocking user input areas, specifically targeting the usability of the search bar.
