### PR TITLE
Fix core data absolute path for `.xcdatamodeld`

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -1549,7 +1549,7 @@
 			);
 			currentVersion = B32B60C12C864BB2007DDCE3 /* WidgetData.xcdatamodel */;
 			name = WidgetData.xcdatamodeld;
-			path = /Users/gustavomunhoz/Documents/Apps/Macro/App/Modulite/Modulite/Models/WidgetData.xcdatamodeld;
+			path = WidgetData.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};


### PR DESCRIPTION
## Description

This PR addresses the bug where CoreData's `.xcdatamodeld` file path would be absolute, leading to different machines being unable to build the project. 

The path is now relative to the project.
### Further steps
Still need to test whether this will cause further problems, but the solution seems promising.