### PR TITLE
Widget Editor Dismissal on Creation

### DIFF
--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -32,8 +32,15 @@ class HomeCoordinator: Coordinator {
 }
 
 extension HomeCoordinator: HomeViewControllerDelegate {
-    func startWidgetCreationNavigationFlow() {
+    func homeViewControllerDidStartWidgetCreationFlow(
+        _ viewController: HomeViewController
+    ) {
         let coordinator = WidgetBuilderCoordinator(router: router)
+        
+        coordinator.onWidgetSave = { widget in
+            viewController.registerNewWidget(widget)
+        }
+        
         presentChild(coordinator, animated: true)
     }
 }

--- a/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
+++ b/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class WidgetBuilderCoordinator: Coordinator {
     
+    // MARK: - Properties
     let contentBuilder = WidgetContentBuilder()
     
     var configurationBuilder: WidgetConfigurationBuilder {
@@ -17,15 +18,22 @@ class WidgetBuilderCoordinator: Coordinator {
     }
     
     var children: [Coordinator] = []
-    
     var router: Router
+    
+    var onWidgetSave: ((ModuliteWidgetConfiguration) -> Void)?
+    
+    // MARK: - Lifecycle
     
     init(router: Router) {
         self.router = router
     }
     
     func present(animated: Bool, onDismiss: (() -> Void)?) {
-        let viewController = WidgetSetupViewController.instantiate(widgetId: UUID(), delegate: self)
+        let viewController = WidgetSetupViewController.instantiate(
+            widgetId: UUID(),
+            delegate: self
+        )
+        
         viewController.hidesBottomBarWhenPushed = true
         
         router.present(viewController, animated: animated, onDismiss: onDismiss)
@@ -91,5 +99,11 @@ extension WidgetBuilderCoordinator: SelectAppsViewControllerDelegate {
 
 // MARK: - WidgetEditorViewControllerDelegate
 extension WidgetBuilderCoordinator: WidgetEditorViewControllerDelegate {
-    
+    func widgetEditorViewController(
+        _ viewController: WidgetEditorViewController,
+        didSave widget: ModuliteWidgetConfiguration
+    ) {
+        onWidgetSave?(widget)
+        dismiss(animated: true)
+    }
 }

--- a/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
+++ b/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
@@ -14,7 +14,7 @@ class ModuliteWidgetConfiguration {
     var widgetStyle: WidgetStyle?
     var modules: [ModuleConfiguration] = []
     
-    var resultingImage: UIImage?
+    var previewImage: UIImage?
     
     var availableStyles: [ModuleStyle] {
         guard let widgetStyle = widgetStyle else { return [] }
@@ -61,6 +61,6 @@ extension ModuliteWidgetConfiguration {
             }
         )
         
-        resultingImage = FileManagerImagePersistenceController.shared.getWidgetImage(with: config.id)
+        previewImage = FileManagerImagePersistenceController.shared.getWidgetImage(with: config.id)
     }
 }

--- a/Modulite/Models/Widget/Persistence/PersistableWidgetConfiguration+CoreDataProperties.swift
+++ b/Modulite/Models/Widget/Persistence/PersistableWidgetConfiguration+CoreDataProperties.swift
@@ -12,24 +12,25 @@ import UIKit
 extension PersistableWidgetConfiguration {
     @NSManaged var id: UUID
     @NSManaged var name: String?
-    @NSManaged var resultingImageURL: URL
+    @NSManaged var previewImageUrl: URL
     @NSManaged var widgetStyleKey: String
     @NSManaged var modules: NSSet
 }
 
 extension PersistableWidgetConfiguration {
+    
+    @discardableResult
     static func createFromWidgetConfiguration(
         _ config: ModuliteWidgetConfiguration,
         widgetImage: UIImage,
         using managedObjectContext: NSManagedObjectContext
-    ) {
+    ) -> PersistableWidgetConfiguration {
         let widget = PersistableWidgetConfiguration(context: managedObjectContext)
         
         widget.id = UUID()
         widget.name = config.name
         guard let widgetStyleKey = config.widgetStyle?.key else {
-            print("Unable to get widget style key. Aborting object creation.")
-            return
+            fatalError("Unable to get widget style key. Aborting object creation.")
         }
         
         widget.widgetStyleKey = widgetStyleKey.rawValue
@@ -39,7 +40,7 @@ extension PersistableWidgetConfiguration {
             for: widget.id
         )
         
-        widget.resultingImageURL = widgetImageUrl
+        widget.previewImageUrl = widgetImageUrl
         
         for module in config.modules {
             let moduleImage = module.generateWidgetButtonImage()
@@ -57,6 +58,7 @@ extension PersistableWidgetConfiguration {
             try managedObjectContext.save()
             
             print("Widget \(widget.id) saved successfully.")
+            return widget
             
         } catch {
             FileManagerImagePersistenceController.shared.deleteWidgetAndModules(with: widget.id)

--- a/Modulite/Models/WidgetData.xcdatamodeld/WidgetData.xcdatamodel/contents
+++ b/Modulite/Models/WidgetData.xcdatamodeld/WidgetData.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23E214" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24A335" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="AppInfo" representedClassName="AppInfo" syncable="YES">
         <attribute name="name" attributeType="String"/>
         <attribute name="urlScheme" attributeType="URI"/>
@@ -16,7 +16,7 @@
     <entity name="PersistableWidgetConfiguration" representedClassName="PersistableWidgetConfiguration" syncable="YES">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="resultingImageURL" attributeType="URI"/>
+        <attribute name="previewImageUrl" attributeType="URI"/>
         <attribute name="widgetStyleKey" optional="YES" attributeType="String"/>
         <relationship name="modules" toMany="YES" minCount="1" maxCount="6" deletionRule="Nullify" destinationEntity="PersistableModuleConfiguration" inverseName="widget" inverseEntity="PersistableModuleConfiguration"/>
     </entity>

--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 protocol HomeViewControllerDelegate: AnyObject {
-    func startWidgetCreationNavigationFlow()
+    func homeViewControllerDidStartWidgetCreationFlow(
+        _ viewController: HomeViewController
+    )
 }
 
 class HomeViewController: UIViewController {
@@ -53,6 +55,12 @@ class HomeViewController: UIViewController {
             print("Image not found")
         }
     }
+    
+    // MARK: - Actions
+    func registerNewWidget(_ widget: ModuliteWidgetConfiguration) {
+        viewModel.mainWidgets.append(widget)
+        homeView.mainWidgetsCollectionView.reloadData()
+    }
 }
 
 extension HomeViewController {
@@ -89,8 +97,8 @@ extension HomeViewController: UICollectionViewDataSource {
                 fatalError("Could not dequeue MainWidgetCollectionViewCell.")
             }
             
-            let widget = viewModel.mainWidgets[indexPath.row] 
-            cell.configure(image: widget.resultingImage, name: widget.name)
+            let widget = viewModel.mainWidgets[indexPath.row]
+            cell.configure(image: widget.previewImage, name: widget.name)
             
             return cell
             
@@ -145,7 +153,7 @@ extension HomeViewController: UICollectionViewDataSource {
                 buttonImage: UIImage(systemName: "plus.circle")!,
                 buttonAction: { [weak self] in
                     guard let self = self else { return }
-                    self.delegate?.startWidgetCreationNavigationFlow()
+                    self.delegate?.homeViewControllerDidStartWidgetCreationFlow(self)
                 }
             )
             
@@ -156,7 +164,7 @@ extension HomeViewController: UICollectionViewDataSource {
                 buttonAction: { [weak self] in
                     guard let self = self else { return }
                     let id = self.viewModel.mainWidgets[indexPath.row]
-                    self.delegate?.startWidgetCreationNavigationFlow()
+                    self.delegate?.homeViewControllerDidStartWidgetCreationFlow(self)
                 }
             )
             

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
@@ -13,7 +13,7 @@ class WidgetEditorView: UIScrollView {
     // MARK: - Properties
     
     var onDownloadWallpaperButtonTapped: (() -> Void)?
-    var onSaveButtonTapped: ((UICollectionView) -> Void)?
+    var onSaveButtonTapped: (() -> Void)?
     
     private let contentView = UIView()
     
@@ -312,7 +312,7 @@ class WidgetEditorView: UIScrollView {
     }
     
     @objc private func didPressSaveButton() {
-        onSaveButtonTapped?(self.widgetLayoutCollectionView)
+        onSaveButtonTapped?()
     }
     
     func updateCollectionViewConstraints(_ collectionView: UICollectionView, percentage: CGFloat) {

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
@@ -8,26 +8,34 @@
 import UIKit
 
 protocol WidgetEditorViewControllerDelegate: AnyObject {
-    
+    func widgetEditorViewController(
+        _ viewController: WidgetEditorViewController,
+        didSave widget: ModuliteWidgetConfiguration
+    )
 }
 
 class WidgetEditorViewController: UIViewController {
     
+    // MARK: - Properties
     private let editorView = WidgetEditorView()
     private var viewModel: WidgetEditorViewModel!
     
+    weak var delegate: WidgetEditorViewControllerDelegate?
+    
+    // MARK: - Lifecycle
     override func loadView() {
         view = editorView
         editorView.setCollectionViewDelegates(to: self)
         editorView.setCollectionViewDataSources(to: self)
         editorView.onDownloadWallpaperButtonTapped = handleDownloadWallpaperTouch
-        editorView.onSaveButtonTapped = viewModel.saveWidget(from:)
+        editorView.onSaveButtonTapped = handleSaveWidgetButtonTouch
         
         if let background = viewModel.getWidgetBackground() {
             editorView.setWidgetBackground(to: background)
         }
     }
     
+    // MARK: - Actions
     private func handleDownloadWallpaperTouch() {
         do {
             try viewModel.saveWallpaperImageToPhotos()
@@ -54,6 +62,13 @@ class WidgetEditorViewController: UIViewController {
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         present(alert, animated: true, completion: nil)
     }
+    
+    func handleSaveWidgetButtonTouch() {
+        clearSelectedModuleCell()
+        
+        let widget = viewModel.saveWidget(from: editorView.widgetLayoutCollectionView)
+        delegate?.widgetEditorViewController(self, didSave: widget)
+    }
 }
 
 extension WidgetEditorViewController {
@@ -64,6 +79,7 @@ extension WidgetEditorViewController {
         let vc = WidgetEditorViewController()
         
         vc.viewModel = WidgetEditorViewModel(widgetBuider: builder)
+        vc.delegate = delegate
         
         return vc
     }

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
@@ -27,8 +27,6 @@ class WidgetEditorViewModel: NSObject {
         super.init()
     }
     
-    
-    
     // MARK: - Getters
     
     func getWidgetBackground() -> WidgetBackground? {
@@ -107,12 +105,19 @@ class WidgetEditorViewModel: NSObject {
         UIImageWriteToSavedPhotosAlbum(resizedHome, nil, nil, nil)
     }
     
-    func saveWidget(from collectionView: UICollectionView) {
+    @discardableResult
+    func saveWidget(from collectionView: UICollectionView) -> ModuliteWidgetConfiguration {
         let widgetConfiguration = builder.build()
-        CoreDataPersistenceController.shared.registerWidget(
+        let persistedConfig = CoreDataPersistenceController.shared.registerWidget(
             widgetConfiguration,
             widgetImage: collectionView.asImage()
         )
+        
+        widgetConfiguration.previewImage = FileManagerImagePersistenceController.shared.getWidgetImage(
+            with: persistedConfig.id
+        )
+        
+        return widgetConfiguration
     }
     
     func moveItem(from sourceIndex: Int, to destinationIndex: Int) {

--- a/Modulite/Singleton/CoreDataPersistenceController.swift
+++ b/Modulite/Singleton/CoreDataPersistenceController.swift
@@ -109,14 +109,17 @@ extension CoreDataPersistenceController {
         }
     }
     
+    @discardableResult
     func registerWidget(
         _ config: ModuliteWidgetConfiguration,
         widgetImage: UIImage
-    ) {
-        PersistableWidgetConfiguration.createFromWidgetConfiguration(
+    ) -> PersistableWidgetConfiguration {
+        let widgetConfig = PersistableWidgetConfiguration.createFromWidgetConfiguration(
             config,
             widgetImage: widgetImage,
             using: container.viewContext
         )
+        
+        return widgetConfig
     }
 }


### PR DESCRIPTION
## Issue Reference

This PR resolves issue [#56 Dismiss WidgetBuilderCoordinator after saving widget in WidgetEditorView](https://github.com/gustavo-munhoz/Modu.lite/issues/56#issue-2543342537).

## Summary

This PR introduces improvements to the widget creation flow and resolves a bug related to widget preview saving. Below are the key changes:

1. **Widget Save Dismisses Creation Flow**: After a user successfully saves a widget, the flow now automatically dismisses, improving the user experience and streamlining the process.
2. **HomeViewController Updates After Dismiss**: When the creation flow is dismissed, the `HomeViewController` is refreshed to display the newly created widget, ensuring that the UI reflects the latest state.
3. **Bug Fix - Widget Preview Saved in Edit State**: Fixed an issue where the widget preview could be saved while still in an editable state, potentially causing incorrect saved widgets. The widget is now properly finalized before saving.

## Testing

- Verified that saving a widget dismisses the creation flow and updates the `HomeViewController` accordingly.
- Tested the creation flow to ensure that the preview is correctly finalized before saving.
- Checked that the new widget appears immediately on the `HomeViewController` after saving and dismissing.

This PR resolves these issues and improves the overall widget creation experience.