### PR TITLE
Fix Widget Preview Sizing in Widget Setup

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -128,6 +128,8 @@
 		B3850BCB2C979FB500F400C0 /* UIEdgeInsetExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3850BCA2C979FB500F400C0 /* UIEdgeInsetExtensionTests.swift */; };
 		B3850BCD2C97A08B00F400C0 /* UICollectionViewExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3850BCC2C97A08B00F400C0 /* UICollectionViewExtensionTests.swift */; };
 		B3987DFF2CA202C100896414 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B3987DFE2CA202C100896414 /* InfoPlist.xcstrings */; };
+		B3987E042CA3602900896414 /* UIView+animateBorderColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3987E032CA3602900896414 /* UIView+animateBorderColor.swift */; };
+		B3987E052CA3602900896414 /* UIView+animateBorderColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3987E032CA3602900896414 /* UIView+animateBorderColor.swift */; };
 		B3C1877F2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C1877E2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift */; };
 		B3C187822C79009B00A891A8 /* WidgetConfigurationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C187812C79009B00A891A8 /* WidgetConfigurationBuilder.swift */; };
 		B3C187842C791D1300A891A8 /* WidgetStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C187832C791D1300A891A8 /* WidgetStyle.swift */; };
@@ -286,6 +288,7 @@
 		B3850BCA2C979FB500F400C0 /* UIEdgeInsetExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEdgeInsetExtensionTests.swift; sourceTree = "<group>"; };
 		B3850BCC2C97A08B00F400C0 /* UICollectionViewExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensionTests.swift; sourceTree = "<group>"; };
 		B3987DFE2CA202C100896414 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		B3987E032CA3602900896414 /* UIView+animateBorderColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+animateBorderColor.swift"; sourceTree = "<group>"; };
 		B3C1877E2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuliteWidgetConfiguration.swift; sourceTree = "<group>"; };
 		B3C187812C79009B00A891A8 /* WidgetConfigurationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetConfigurationBuilder.swift; sourceTree = "<group>"; };
 		B3C187832C791D1300A891A8 /* WidgetStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStyle.swift; sourceTree = "<group>"; };
@@ -550,6 +553,7 @@
 		B34F3E292C6E83670041D7BD /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B3987E032CA3602900896414 /* UIView+animateBorderColor.swift */,
 				B34F3E2A2C6E837F0041D7BD /* UIFont+TraitedTextStyle.swift */,
 				B34F3E322C6E8AA60041D7BD /* UITextField+HorizontalPadding.swift */,
 				B3EB15BA2C7E5DC5003B1960 /* UILabel+AppNameConfiguration.swift */,
@@ -1172,6 +1176,7 @@
 				B32B60FB2C87AC8D007DDCE3 /* AppInfoData.swift in Sources */,
 				B37284702C82990B00D9A1E7 /* WidgetStyle.swift in Sources */,
 				AFBBC5072C7E459900A9B256 /* ModuliteWidgetBundle.swift in Sources */,
+				B3987E052CA3602900896414 /* UIView+animateBorderColor.swift in Sources */,
 				B32B60A52C838EB0007DDCE3 /* WidgetModuleCell.swift in Sources */,
 				B32B60FC2C87AC90007DDCE3 /* AppInfo+CoreDataProperties.swift in Sources */,
 				B32B60F52C87AB85007DDCE3 /* WidgetData.xcdatamodeld in Sources */,
@@ -1198,6 +1203,7 @@
 				B34F3E1A2C6B94080041D7BD /* HomeHeaderReusableCell.swift in Sources */,
 				B36927CF2C66B8A30089F769 /* Coordinator.swift in Sources */,
 				B32B60BA2C864807007DDCE3 /* PersistableModuleConfiguration+CoreDataClass.swift in Sources */,
+				B3987E042CA3602900896414 /* UIView+animateBorderColor.swift in Sources */,
 				B34F3E242C6D366A0041D7BD /* WidgetEditorView.swift in Sources */,
 				B3D90AC12C9A570B00CA8054 /* MockImagePersistenceController.swift in Sources */,
 				B369279C2C66B6E30089F769 /* HomeViewController.swift in Sources */,

--- a/Modulite/Extensions/UIView+animateBorderColor.swift
+++ b/Modulite/Extensions/UIView+animateBorderColor.swift
@@ -1,0 +1,19 @@
+//
+//  UIView+animateBorderColor.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 24/09/24.
+//
+
+import UIKit
+
+extension UIView {
+    func animateBorderColor(toColor: UIColor, duration: Double) {
+        let animation = CABasicAnimation(keyPath: "borderColor")
+        animation.fromValue = layer.borderColor
+        animation.toValue = toColor.cgColor
+        animation.duration = duration
+        layer.add(animation, forKey: "borderColor")
+        layer.borderColor = toColor.cgColor
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
@@ -321,6 +321,7 @@ class WidgetEditorView: UIScrollView {
         collectionView.snp.updateConstraints { make in
             make.left.equalToSuperview().offset(-offset)
         }
+        
         UIView.animate(withDuration: 0.3) {
             self.layoutIfNeeded()
         }

--- a/Modulite/Screens/WidgetConfiguration/Setup/View/CollectionViewCells/StyleCollectionViewCell.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/CollectionViewCells/StyleCollectionViewCell.swift
@@ -20,9 +20,7 @@ class StyleCollectionViewCell: UICollectionViewCell {
     
     override var isSelected: Bool {
         didSet {
-            UIView.animate(withDuration: 0.25) {
-                self.updateOverlayAlpha()
-            }
+         updateOverlayAlpha()
         }
     }
     
@@ -45,7 +43,7 @@ class StyleCollectionViewCell: UICollectionViewCell {
         let view = UIView()
         view.backgroundColor = UIColor.black
         view.alpha = 0
-        view.layer.cornerRadius = 12
+        view.layer.cornerRadius = 14
         
         return view
     }()
@@ -93,10 +91,19 @@ class StyleCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Actions
     private func updateOverlayAlpha() {
-        // FIXME: Image size needs to be equal for all
         if hasSelectionBeenMade {
-            overlayView.alpha = isSelected ? 0 : 0.3
-            styleImageView.layer.borderColor = isSelected ? UIColor.lemonYellow.cgColor : .none
+            DispatchQueue.main.async {
+                UIView.animate(withDuration: 0.25) { [weak self] in
+                    guard let self = self else { return }
+                    self.overlayView.alpha = self.isSelected ? 0 : 0.5
+                }
+            }
+            
+            styleImageView.animateBorderColor(
+                toColor: isSelected ? UIColor.lemonYellow : .clear,
+                duration: 0.25
+            )
+            
             styleImageView.layer.borderWidth = isSelected ? 4 : 0
             
         } else {

--- a/Modulite/Screens/WidgetConfiguration/Setup/View/CollectionViewLayouts/WidgetSetupStyleCompositionalLayout.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/CollectionViewLayouts/WidgetSetupStyleCompositionalLayout.swift
@@ -17,8 +17,8 @@ class WidgetSetupStyleCompositionalLayout: UICollectionViewCompositionalLayout {
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             
             let groupSize = NSCollectionLayoutSize(
-                widthDimension: .absolute(192),
-                heightDimension: .absolute(234)
+                widthDimension: .absolute(180),
+                heightDimension: .absolute(196)
             )
             
             let group = NSCollectionLayoutGroup.horizontal(
@@ -28,6 +28,8 @@ class WidgetSetupStyleCompositionalLayout: UICollectionViewCompositionalLayout {
             
             let section = NSCollectionLayoutSection(group: group)
             section.orthogonalScrollingBehavior = .continuous
+            
+            section.interGroupSpacing = 16
             
             if sectionIndex == 0 {
                 let headerSize = NSCollectionLayoutSize(


### PR DESCRIPTION
## Issue Reference

This PR closes #53 [Fix widget preview sizing in WidgetSetupView](https://github.com/gustavo-munhoz/Modu.lite/issues/53#issue-2543341894).

## Summary

This PR fixes the incorrect sizing of the widget preview in `WidgetSetupView` and introduces improvements to the overall layout and interaction experience. The key changes are as follows:

1. **Fixed Widget Preview Sizing**: The widget preview now renders with the correct dimensions, ensuring consistency and alignment within the view.
2. **Adjusted Spacing Between Cells**: The spacing between widget cells has been improved, providing a cleaner and more balanced look.
3. **Added Border Animations**: Animations have been added to the widget borders to enhance user interaction and give a more polished feel to the preview process.

## Known Issues / Future Improvements

- **OverlayView Alpha Animation Issue**: The alpha animation for `overlayView` is not behaving as expected, likely due to the state handling within the parent `UICollectionView`. This will need to be addressed in a future update to ensure smooth transitions.

## Testing

- Verified that the widget preview is now rendered with the correct sizing in `WidgetSetupView`.
- Checked the visual improvements in the spacing between widget cells to ensure a consistent layout.
- Tested the border animations to confirm they are triggered properly during user interactions.

This PR addresses the main issue of incorrect widget sizing and adds some enhancements to the widget setup UI, though there is an outstanding issue with the overlay animation that will be handled separately.
