### PR TITLE
Implemented Widget Sorting by Creation Date

### DIFF
--- a/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
+++ b/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
@@ -26,16 +26,20 @@ class ModuliteWidgetConfiguration {
         return widgetStyle.colors
     }
     
+    var createdAt: Date!
+    
     init() { }
     
     init(
         name: String? = nil,
         style: WidgetStyle,
-        modules: [ModuleConfiguration]
+        modules: [ModuleConfiguration],
+        createdAt: Date
     ) {
         self.name = name
         self.widgetStyle = style
         self.modules = modules
+        self.createdAt = createdAt
     }
 }
 
@@ -58,7 +62,8 @@ extension ModuliteWidgetConfiguration {
                     widgetStyle: style,
                     persistedConfiguration: $0
                 )
-            }
+            },
+            createdAt: config.createdAt
         )
         
         previewImage = FileManagerImagePersistenceController.shared.getWidgetImage(with: config.id)

--- a/Modulite/Models/Widget/Persistence/PersistableWidgetConfiguration+CoreDataProperties.swift
+++ b/Modulite/Models/Widget/Persistence/PersistableWidgetConfiguration+CoreDataProperties.swift
@@ -15,6 +15,7 @@ extension PersistableWidgetConfiguration {
     @NSManaged var previewImageUrl: URL
     @NSManaged var widgetStyleKey: String
     @NSManaged var modules: NSSet
+    @NSManaged var createdAt: Date
 }
 
 extension PersistableWidgetConfiguration {

--- a/Modulite/Models/WidgetData.xcdatamodeld/WidgetData.xcdatamodel/contents
+++ b/Modulite/Models/WidgetData.xcdatamodeld/WidgetData.xcdatamodel/contents
@@ -14,6 +14,7 @@
         <relationship name="widget" maxCount="1" deletionRule="Nullify" destinationEntity="PersistableWidgetConfiguration" inverseName="modules" inverseEntity="PersistableWidgetConfiguration"/>
     </entity>
     <entity name="PersistableWidgetConfiguration" representedClassName="PersistableWidgetConfiguration" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="previewImageUrl" attributeType="URI"/>

--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -58,7 +58,7 @@ class HomeViewController: UIViewController {
     
     // MARK: - Actions
     func registerNewWidget(_ widget: ModuliteWidgetConfiguration) {
-        viewModel.mainWidgets.append(widget)
+        viewModel.addMainWidget(widget)
         homeView.mainWidgetsCollectionView.reloadData()
     }
 }

--- a/Modulite/Screens/Home/ViewModel/HomeViewModel.swift
+++ b/Modulite/Screens/Home/ViewModel/HomeViewModel.swift
@@ -6,9 +6,10 @@
 //
 
 import UIKit
-import Combine
 
 class HomeViewModel: NSObject {
+    
+    // MARK: - Properties
     
     @Published var mainWidgets: [ModuliteWidgetConfiguration]
     
@@ -19,11 +20,19 @@ class HomeViewModel: NSObject {
     
     @Published var tips: [UIImage] = []
     
+    // MARK: - Init
+    
     override init() {
         let persistedWidgets = CoreDataPersistenceController.shared.fetchWidgets()
         mainWidgets = persistedWidgets.map {
             ModuliteWidgetConfiguration(persistedConfiguration: $0)
         }
         super.init()
+    }
+    
+    // MARK: - Actions
+    
+    func addMainWidget(_ configuration: ModuliteWidgetConfiguration) {
+        mainWidgets.insert(configuration, at: 0)
     }
 }

--- a/Modulite/Singleton/CoreDataPersistenceController.swift
+++ b/Modulite/Singleton/CoreDataPersistenceController.swift
@@ -111,6 +111,8 @@ extension CoreDataPersistenceController {
     
     func fetchWidgets() -> [PersistableWidgetConfiguration] {
         let request = PersistableWidgetConfiguration.basicFetchRequest()
+        let sortDescriptor = NSSortDescriptor(key: "createdAt", ascending: false)
+        request.sortDescriptors = [sortDescriptor]
         
         do {
             return try container.viewContext.fetch(request)
@@ -131,6 +133,8 @@ extension CoreDataPersistenceController {
             widgetImage: widgetImage,
             using: container.viewContext
         )
+        
+        widgetConfig.createdAt = .now
         
         return widgetConfig
     }


### PR DESCRIPTION
## Issue Reference

This PR closes #65 by implementing sorted widgets in `HomeView`.

## Summary

This PR introduces sorting for widgets based on their creation date, ensuring that the most recently created widget appears first. To achieve this, the following changes were made:

1. **Added `createdAt` Property to `PersistableWidgetConfiguration`**: A new `createdAt` property of type `Date` was added to the Core Data model to store the creation timestamp for each widget.
2. **Updated Widget Creation Logic**: The widget creation logic now sets the `createdAt` property to the current date and time when a widget is created, ensuring accurate tracking of creation order.
3. **Fetch Request Sorting**: The fetch request for widgets was updated to include a sort descriptor based on `createdAt`, ordering the results with the most recent widget first.

## Testing

- Verified that widgets are now sorted by creation date, with the most recent widget appearing at the top.
- Tested the widget creation process to ensure that the `createdAt` property is correctly assigned during widget registration.

This PR enhances the user experience by presenting widgets in a logical and expected order, based on when they were created.