### PR TITLE
Fixed Widget Names Not Being Set

### DIFF
--- a/Modulite/Builders/WidgetContentBuilder.swift
+++ b/Modulite/Builders/WidgetContentBuilder.swift
@@ -8,7 +8,7 @@
 class WidgetContentBuilder {
     
     // MARK: - Properties
-    private var name: String?
+    private var name: String!
     private var style: WidgetStyle!
     private var apps: [AppInfo] = []
     
@@ -21,6 +21,7 @@ class WidgetContentBuilder {
     func setWidgetName(_ name: String) {
         self.name = name
     }
+    
     func setWidgetStyle(_ style: WidgetStyle) {
         self.style = style
     }

--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -35,7 +35,10 @@ extension HomeCoordinator: HomeViewControllerDelegate {
     func homeViewControllerDidStartWidgetCreationFlow(
         _ viewController: HomeViewController
     ) {
-        let coordinator = WidgetBuilderCoordinator(router: router)
+        let coordinator = WidgetBuilderCoordinator(
+            router: router,
+            currentWidgetCount: viewController.getCurrentMainWidgetCount()
+        )
         
         coordinator.onWidgetSave = { widget in
             viewController.registerNewWidget(widget)

--- a/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
+++ b/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
@@ -22,9 +22,17 @@ class WidgetBuilderCoordinator: Coordinator {
     
     var onWidgetSave: ((ModuliteWidgetConfiguration) -> Void)?
     
+    var currentWidgetCount: Int
+    
     // MARK: - Lifecycle
     
     init(router: Router) {
+        self.router = router
+        self.currentWidgetCount = 0
+    }
+    
+    init(router: Router, currentWidgetCount: Int) {
+        self.currentWidgetCount = currentWidgetCount
         self.router = router
     }
     
@@ -42,6 +50,12 @@ class WidgetBuilderCoordinator: Coordinator {
 
 // MARK: - WidgetSetupViewControllerDelegate
 extension WidgetBuilderCoordinator: WidgetSetupViewControllerDelegate {
+    func getPlaceholderName() -> String {
+        .localized(
+            for: .widgetSetupViewMainWidgetNamePlaceholder(number: currentWidgetCount + 1)
+        )
+    }
+    
     func widgetSetupViewControllerDidPressNext(widgetName: String) {
         contentBuilder.setWidgetName(widgetName)
         

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -416,6 +416,17 @@
         }
       }
     },
+    "widgetSetupViewMainWidgetNamePlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Main Widget %d"
+          }
+        }
+      }
+    },
     "widgetSetupViewSearchAppsButtonTitle" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modulite/Localization/String+LocalizedKey.swift
+++ b/Modulite/Localization/String+LocalizedKey.swift
@@ -102,6 +102,7 @@ extension String {
         case homeViewWidgetContextMenuDeleteTitle
         
         // MARK: - WidgetSetupView & WidgetSetupViewController
+        case widgetSetupViewMainWidgetNamePlaceholder(number: Int)
         case widgetSetupViewStyleHeaderTitle
         case widgetSetupViewAppsHeaderTitle
         case widgetSetupViewSearchAppsButtonTitle

--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -57,6 +57,10 @@ class HomeViewController: UIViewController {
     }
     
     // MARK: - Actions
+    func getCurrentMainWidgetCount() -> Int {
+        viewModel.mainWidgets.count
+    }
+    
     func registerNewWidget(_ widget: ModuliteWidgetConfiguration) {
         viewModel.addMainWidget(widget)
         homeView.mainWidgetsCollectionView.reloadData()

--- a/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
@@ -131,7 +131,11 @@ class WidgetSetupView: UIScrollView {
     
     // MARK: - Actions
     func getWidgetName() -> String {
-        widgetNameTextField.text ?? widgetNameTextField.placeholder!
+        guard let name = widgetNameTextField.text, !name.isEmpty else {
+            return widgetNameTextField.placeholder!
+        }
+        
+        return widgetNameTextField.text!
     }
     
     func updateButtonConfig() {

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 protocol WidgetSetupViewControllerDelegate: AnyObject {
+    func getPlaceholderName() -> String
+    
     func widgetSetupViewControllerDidPressNext(widgetName: String)
     
     func widgetSetupViewControllerDidTapSearchApps(
@@ -54,6 +56,10 @@ class WidgetSetupViewController: UIViewController {
         setupView.onSearchButtonPressed = presentSearchModal
     }
     
+    private func setPlaceholderName(to name: String) {
+        setupView.widgetNameTextField.placeholder = name
+    }
+    
     // MARK: - Actions
     func didFinishSelectingApps(apps: [AppInfo]) {
         setSetupViewHasAppsSelected(to: !apps.isEmpty)
@@ -88,6 +94,8 @@ extension WidgetSetupViewController {
         let vc = WidgetSetupViewController()
         vc.delegate = delegate
         vc.viewModel.setWidgetId(to: widgetId)
+        
+        vc.setPlaceholderName(to: delegate.getPlaceholderName())
         
         return vc
     }


### PR DESCRIPTION
## Issue Reference

This PR closes #68 and introduces improvements to widget naming logic, along with a bug fix related to widget name handling.

## Summary

The following changes have been made:

1. **Auto-incremented Widget Names**: The `WidgetBuilderCoordinator` now provides the widget count to the `WidgetSetupViewController`, enabling automatic name generation with an auto-increment feature. This ensures that each new widget gets a unique, incremented name by default.
   
2. **Fixed Widget Name Bug**: Resolved an issue where the widget name could remain empty due to an optional check on the `widgetNameTextField`. The bug occurred when the text field existed but was empty, and the optional handling incorrectly allowed an empty name. This has been corrected to ensure proper widget name validation.

## Testing

- Verified that widget names are now auto-incremented and correctly displayed during the widget creation process.
- Confirmed that the bug causing empty widget names no longer occurs, and the `widgetNameTextField` properly validates the name input.