### PR TITLE
Implemented Edit and Delete Context Menu Actions for Widgets in HomeView

### DIFF
--- a/Modulite/Builders/WidgetConfigurationBuilder.swift
+++ b/Modulite/Builders/WidgetConfigurationBuilder.swift
@@ -40,6 +40,11 @@ class WidgetConfigurationBuilder {
         }
     }
     
+    init(content: WidgetContent, configuration: ModuliteWidgetConfiguration) {
+        widgetContent = content
+        self.configuration = configuration
+    }
+    
     // MARK: - Getters
     func getStyleWallpapers() -> (blocked: UIImage, home: UIImage) {
         (widgetContent.style.blockedScreenWallpaperImage, widgetContent.style.homeScreenWallpaperImage)

--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -46,4 +46,18 @@ extension HomeCoordinator: HomeViewControllerDelegate {
         
         presentChild(coordinator, animated: true)
     }
+    
+    func homeViewControllerDidStartWidgetEditingFlow(
+        _ viewController: HomeViewController,
+        widget: ModuliteWidgetConfiguration
+    ) {
+        let coordinator = WidgetBuilderCoordinator(
+            router: router,
+            configuration: widget
+        )
+        
+        // TODO: Add onWidgetSave
+        
+        presentChild(coordinator, animated: true)
+    }
 }

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -26,6 +26,28 @@
         }
       }
     },
+    "cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
     "homeViewAuxiliarySectionHeaderTitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -44,6 +66,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Home"
+          }
+        }
+      }
+    },
+    "homeViewDeleteWidgetAlertMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to delete this widget? This action cannot be undone."
+          }
+        }
+      }
+    },
+    "homeViewDeleteWidgetAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete %@?"
           }
         }
       }

--- a/Modulite/Localization/String+LocalizedKey.swift
+++ b/Modulite/Localization/String+LocalizedKey.swift
@@ -87,6 +87,8 @@ extension String {
         // MARK: - Reusable texts
         case next
         case save
+        case cancel
+        case delete
         
         // MARK: Tab Bar Titles
         case homeViewControllerTabBarItemTitle
@@ -100,6 +102,8 @@ extension String {
         case homeViewTipsSectionHeaderTitle
         case homeViewWidgetContextMenuEditTitle
         case homeViewWidgetContextMenuDeleteTitle
+        case homeViewDeleteWidgetAlertTitle(widgetName: String)
+        case homeViewDeleteWidgetAlertMessage
         
         // MARK: - WidgetSetupView & WidgetSetupViewController
         case widgetSetupViewMainWidgetNamePlaceholder(number: Int)

--- a/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
+++ b/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
@@ -10,6 +10,7 @@ import UIKit
 /// Manages the overall configuration of a widget, including its background and modules.
 
 class ModuliteWidgetConfiguration {
+    var id: UUID = UUID()
     var name: String?
     var widgetStyle: WidgetStyle?
     var modules: [ModuleConfiguration] = []
@@ -31,11 +32,13 @@ class ModuliteWidgetConfiguration {
     init() { }
     
     init(
+        id: UUID,
         name: String? = nil,
         style: WidgetStyle,
         modules: [ModuleConfiguration],
         createdAt: Date
     ) {
+        self.id = id
         self.name = name
         self.widgetStyle = style
         self.modules = modules
@@ -55,6 +58,7 @@ extension ModuliteWidgetConfiguration {
         
         let style = WidgetStyleFactory.styleForKey(key)
         self.init(
+            id: config.id,
             name: config.name,
             style: style,
             modules: moduleArray.map {

--- a/Modulite/Models/Widget/Persistence/PersistableWidgetConfiguration+CoreDataProperties.swift
+++ b/Modulite/Models/Widget/Persistence/PersistableWidgetConfiguration+CoreDataProperties.swift
@@ -28,7 +28,7 @@ extension PersistableWidgetConfiguration {
     ) -> PersistableWidgetConfiguration {
         let widget = PersistableWidgetConfiguration(context: managedObjectContext)
         
-        widget.id = UUID()
+        widget.id = config.id
         widget.name = config.name
         guard let widgetStyleKey = config.widgetStyle?.key else {
             fatalError("Unable to get widget style key. Aborting object creation.")
@@ -71,7 +71,7 @@ extension PersistableWidgetConfiguration {
             return widget
             
         } catch {
-            FileManagerImagePersistenceController.shared.deleteWidgetAndModules(with: widget.id)
+            FileManagerImagePersistenceController.shared.deleteWidgetAndModules(widgetId: widget.id)
             fatalError("Error creating widget persistent config: \(error.localizedDescription)")
         }
     }

--- a/Modulite/Models/WidgetData.xcdatamodeld/WidgetData.xcdatamodel/contents
+++ b/Modulite/Models/WidgetData.xcdatamodeld/WidgetData.xcdatamodel/contents
@@ -19,6 +19,6 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="previewImageUrl" attributeType="URI"/>
         <attribute name="widgetStyleKey" optional="YES" attributeType="String"/>
-        <relationship name="modules" toMany="YES" minCount="1" maxCount="6" deletionRule="Nullify" destinationEntity="PersistableModuleConfiguration" inverseName="widget" inverseEntity="PersistableModuleConfiguration"/>
+        <relationship name="modules" toMany="YES" minCount="6" maxCount="6" deletionRule="Cascade" destinationEntity="PersistableModuleConfiguration" inverseName="widget" inverseEntity="PersistableModuleConfiguration"/>
     </entity>
 </model>

--- a/Modulite/Screens/Home/View/CollectionViewCells/MainWidgetCollectionViewCell.swift
+++ b/Modulite/Screens/Home/View/CollectionViewCells/MainWidgetCollectionViewCell.swift
@@ -47,6 +47,10 @@ class MainWidgetCollectionViewCell: UICollectionViewCell {
         return view
     }()
     
+    var widgetName: String {
+        widgetNameLabel.text!
+    }
+    
     // MARK: - Initializers
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Modulite/Screens/Home/View/CollectionViewCells/MainWidgetCollectionViewCell.swift
+++ b/Modulite/Screens/Home/View/CollectionViewCells/MainWidgetCollectionViewCell.swift
@@ -91,7 +91,9 @@ extension MainWidgetCollectionViewCell: UIContextMenuInteractionDelegate {
             return UIContextMenuConfiguration(
                 identifier: nil,
                 previewProvider: nil,
-                actionProvider: { _ in
+                actionProvider: { [weak self] _ in
+                    guard let self = self else { return nil }
+                    
                     return self.makeContextMenu()
                 }
             )
@@ -101,18 +103,22 @@ extension MainWidgetCollectionViewCell: UIContextMenuInteractionDelegate {
         let editAction = UIAction(
             title: .localized(for: .homeViewWidgetContextMenuEditTitle),
             image: UIImage(systemName: "pencil")
-        ) { [weak self] action in
-//            self?.editWidget(widget, at: indexPath)
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            
+            self.delegate?.mainWidgetCellDidRequestEdit(self)
         }
         
         let deleteAction = UIAction(
             title: .localized(for: .homeViewWidgetContextMenuDeleteTitle),
             image: UIImage(systemName: "trash"),
             attributes: .destructive
-        ) { [weak self] action in
-//            self?.deleteWidget(widget, at: indexPath)
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            
+            self.delegate?.mainWidgetCellDidRequestDelete(self)
         }
         
-        return UIMenu(title: "", children: [editAction, deleteAction])
+        return UIMenu(title: widgetNameLabel.text!, children: [editAction, deleteAction])
     }
 }

--- a/Modulite/Screens/Home/ViewModel/HomeViewModel.swift
+++ b/Modulite/Screens/Home/ViewModel/HomeViewModel.swift
@@ -30,9 +30,40 @@ class HomeViewModel: NSObject {
         super.init()
     }
     
+    // MARK: - Getters
+    
+    func getIndexFor(_ config: ModuliteWidgetConfiguration) -> Int? {
+        guard let index = mainWidgets.firstIndex(where: { $0.id == config.id }) else {
+            print("Widget not found in data source")
+            return nil
+        }
+        
+        return index
+    }
+    
     // MARK: - Actions
     
     func addMainWidget(_ configuration: ModuliteWidgetConfiguration) {
         mainWidgets.insert(configuration, at: 0)
+    }
+    
+    func deleteMainWidget(at idx: Int) {
+        guard idx >= 0, idx < mainWidgets.count else {
+            print("Tried to delete a widget at an invalid index.")
+            return
+        }
+            
+        let id = mainWidgets[idx].id
+        CoreDataPersistenceController.shared.deleteWidget(withId: id)
+        mainWidgets.remove(at: idx)
+    }
+    
+    func deleteMainWidget(_ configuration: ModuliteWidgetConfiguration) {
+        guard let idx = mainWidgets.firstIndex(where: { $0.id == configuration.id }) else {
+            print("Tried to delete a widget that is not registered")
+            return
+        }
+        
+        deleteMainWidget(at: idx)
     }
 }

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
@@ -83,6 +83,10 @@ extension WidgetEditorViewController {
         
         return vc
     }
+    
+    func loadDataFromBuilder(_ builder: WidgetConfigurationBuilder) {
+        viewModel = WidgetEditorViewModel(widgetBuider: builder)
+    }
 }
 
 // MARK: - UICollectionViewDataSource

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Combine
 
 class WidgetEditorViewModel: NSObject {
     

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
@@ -90,14 +90,23 @@ class WidgetSetupViewController: UIViewController {
 }
 
 extension WidgetSetupViewController {
-    class func instantiate(widgetId: UUID, delegate: WidgetSetupViewControllerDelegate) -> WidgetSetupViewController {
+    class func instantiate(delegate: WidgetSetupViewControllerDelegate) -> WidgetSetupViewController {
         let vc = WidgetSetupViewController()
         vc.delegate = delegate
-        vc.viewModel.setWidgetId(to: widgetId)
-        
         vc.setPlaceholderName(to: delegate.getPlaceholderName())
         
         return vc
+    }
+    
+    func loadDataFromContent(_ content: WidgetContent) {
+        setupView.widgetNameTextField.text = content.name
+        viewModel.setWidgetStyle(to: content.style)
+        guard let apps = content.apps.filter({ $0 != nil }) as? [AppInfo] else { return }
+        
+        viewModel.setSelectedApps(to: apps)
+        
+        setSetupViewStyleSelected(to: true)
+        setSetupViewHasAppsSelected(to: true)
     }
 }
 

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
@@ -16,6 +16,7 @@ class WidgetSetupViewModel: NSObject {
         WidgetStyleFactory.styleForKey(.tapedeck)
     ]
     
+    @Published private(set) var widgetName: String?
     @Published private(set) var selectedStyle: WidgetStyle?
     @Published private(set) var selectedApps: [AppInfo] = []
     
@@ -30,7 +31,13 @@ class WidgetSetupViewModel: NSObject {
         self.widgetId = id
     }
     
-    // MARK: - Actions
+    func setWidgetName(to name: String) {
+        self.widgetName = name
+    }
+    
+    func setWidgetStyle(to style: WidgetStyle) {
+        self.selectedStyle = style
+    }
     
     func setSelectedApps(to apps: [AppInfo]) {
         guard apps.count <= 6 else {
@@ -41,6 +48,8 @@ class WidgetSetupViewModel: NSObject {
         selectedApps = apps
     }
     
+    // MARK: - Actions
+        
     func addSelectedApp(_ app: AppInfo) {
         guard selectedApps.count < 6 else {
             print("Tried to add more than 6 apps.")

--- a/Modulite/Singleton/CoreDataPersistenceController.swift
+++ b/Modulite/Singleton/CoreDataPersistenceController.swift
@@ -74,16 +74,22 @@ struct CoreDataPersistenceController {
 // MARK: - AppInfo
 extension CoreDataPersistenceController {
     
-    func fetchApps() -> [AppInfo] {
+    func fetchApps(predicate: NSPredicate? = nil) -> [AppInfo] {
         let request = AppInfo.nameSortedFetchRequest()
+        request.predicate = predicate
         do {
             let apps = try container.viewContext.fetch(request)
             return apps
-            
         } catch {
             print("Error fetching apps: \(error.localizedDescription)")
             return []
         }
+    }
+    
+    func fetchAppInfo(named name: String, urlScheme: String) -> AppInfo? {
+        let predicate = NSPredicate(format: "name == %@ AND urlScheme == %@", name, urlScheme)
+        let apps = CoreDataPersistenceController.shared.fetchApps(predicate: predicate)
+        return apps.first
     }
     
     private func populateAppsAtFirstExecution() {

--- a/Modulite/Singleton/CoreDataPersistenceController.swift
+++ b/Modulite/Singleton/CoreDataPersistenceController.swift
@@ -124,6 +124,29 @@ extension CoreDataPersistenceController {
         }
     }
     
+    func deleteWidget(withId id: UUID) {
+        let context = container.viewContext
+        let request = PersistableWidgetConfiguration.basicFetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        
+        do {
+            guard let widget = try context.fetch(request).first else {
+                print("Widget with id \(id) not found.")
+                return
+            }
+            
+            context.delete(widget)
+            
+            try context.save()
+            
+            FileManagerImagePersistenceController.shared.deleteWidgetAndModules(widgetId: id)
+            print("Widget with id \(id) deleted successfully from CoreData.")
+            
+        } catch {
+            print("Error deleting widget from CoreData: \(error.localizedDescription)")
+        }
+    }
+    
     @discardableResult
     func registerWidget(
         _ config: ModuliteWidgetConfiguration,

--- a/Modulite/Singleton/WidgetImagePersistence/FileManagerImagePersistenceController.swift
+++ b/Modulite/Singleton/WidgetImagePersistence/FileManagerImagePersistenceController.swift
@@ -97,14 +97,15 @@ class FileManagerImagePersistenceController {
     
     // MARK: - Delete images
     
-    func deleteWidgetAndModules(with id: UUID) {
+    func deleteWidgetAndModules(widgetId id: UUID) {
         let widgetDirectory = getDirectory(for: id)
         
         do {
             try FileManager.default.removeItem(at: widgetDirectory)
-            print("Successfully deleted widget with ID \(id)")
+            print("Successfully deleted widget images.")
+            
         } catch {
-            print("Failed to delete widget with ID \(id): \(error)")
+            print("Failed to delete widget images for ID \(id): \(error)")
         }
     }
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #84, introducing context menu actions for managing widgets, including both edit and delete options.

## Summary

The following key changes have been implemented:

1. **Context Menu Actions for Widgets**: Added context menu actions to widgets, allowing users to interact with the widget through options like **edit** and **delete**. These actions provide a more intuitive way for users to manage their widgets directly from the interface.
   
2. **Edit and Delete Widget Methods**: Implemented the methods required for handling the **edit** and **delete** functionality for widgets. The delete option removes the selected widget from the view and its associated data, while the edit option initiates the widget editing process.
   
3. **Widget Deletion Logic**: The widget deletion is now fully functional, with appropriate prompts and localized delete confirmation alerts. This ensures a smooth user experience when removing widgets.

## Known Limitations

- **Widget Edit Persistence**: While the **edit** functionality has been implemented in terms of UI interaction, the logic to **update the widget in CoreData** after editing is not yet fully functional. This will require further work to persist the changes to the database once the widget configuration has been modified.

## Next Steps

- Implement the missing CoreData persistence logic for edited widgets, ensuring that changes made through the edit menu option are saved and reflected across the app.
- Test the edit functionality thoroughly after persistence is implemented to ensure the correct synchronization between the app and the stored data.