### PR TITLE
Implemented Widget Editing Persistence

### DIFF
--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import WidgetKit
 
 /// A `Coordinator` that manages the presentation of the home screen in the application.
 class HomeCoordinator: Coordinator {
@@ -56,7 +57,11 @@ extension HomeCoordinator: HomeViewControllerDelegate {
             configuration: widget
         )
         
-        // TODO: Add onWidgetSave
+        coordinator.onWidgetSave = { widget in
+            CoreDataPersistenceController.shared.updateWidget(widget)
+            viewController.updateMainWidget(widget)
+            WidgetCenter.shared.reloadAllTimelines()
+        }
         
         presentChild(coordinator, animated: true)
     }

--- a/Modulite/Models/Widget/Persistence/PersistableWidgetConfiguration+CoreDataProperties.swift
+++ b/Modulite/Models/Widget/Persistence/PersistableWidgetConfiguration+CoreDataProperties.swift
@@ -47,7 +47,6 @@ extension PersistableWidgetConfiguration {
         
         // FIXME: Module count is sometimes 5 after fetching
         for module in config.modules {
-            print("Saving module with index \(module.index)")
             guard let moduleImage = module.generateWidgetButtonImage() else {
                 fatalError("Could not generate module image")
             }

--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -66,6 +66,21 @@ class HomeViewController: UIViewController {
         viewModel.mainWidgets.count
     }
     
+    func updateMainWidget(_ widget: ModuliteWidgetConfiguration) {
+        viewModel.updateMainWidget(widget)
+        
+        guard let index = viewModel.getIndexFor(widget) else {
+            print("Widget not found in data source.")
+            return
+        }
+        
+        let indexPath = IndexPath(item: index, section: 0)
+        
+        homeView.mainWidgetsCollectionView.performBatchUpdates { [weak self] in
+            self?.homeView.mainWidgetsCollectionView.reloadItems(at: [indexPath])
+        }
+    }
+    
     func registerNewWidget(_ widget: ModuliteWidgetConfiguration) {
         viewModel.addMainWidget(widget)
         

--- a/Modulite/Screens/Home/ViewModel/HomeViewModel.swift
+++ b/Modulite/Screens/Home/ViewModel/HomeViewModel.swift
@@ -47,6 +47,15 @@ class HomeViewModel: NSObject {
         mainWidgets.insert(configuration, at: 0)
     }
     
+    func updateMainWidget(_ configuration: ModuliteWidgetConfiguration) {
+        guard let idx = getIndexFor(configuration) else {
+            print("Tried to update a widget at an invalid index.")
+            return
+        }
+        
+        mainWidgets[idx] = configuration
+    }
+    
     func deleteMainWidget(at idx: Int) {
         guard idx >= 0, idx < mainWidgets.count else {
             print("Tried to delete a widget at an invalid index.")


### PR DESCRIPTION
## Issue Reference

This PR closes #86 by implementing widget editing functionality in the `WidgetEditorView`. Now, when a user saves a widget, any changes made to its configuration are properly persisted.

## Summary

The following key changes have been made:

1. **Widget Editing on Save**: Implemented the logic to edit existing widgets when the user clicks "Save Widget" in the `WidgetEditorView`. This allows users to update an existing widget’s configuration and have those changes reflected immediately.
   
2. **CoreData Persistence for Edited Widgets**: Ensured that when a widget is edited and saved, the updated configuration is correctly persisted in CoreData. This allows the changes to be retained across app sessions and reflected both in the app and in the widget.
   
3. **Synchronized Updates in View**: After saving, the updated widget configuration is automatically reflected in the UI, ensuring that the user sees the latest changes without needing to manually refresh the view.

## Testing

- Verified that the widget edit functionality works as expected when saving from the `WidgetEditorView`.
- Confirmed that changes are correctly saved to CoreData and persist across app relaunches.
- Ensured that the updated widget is reflected in the app's UI and the widget itself after editing.