### PR TITLE
Navigation Title for Editing Views

### DIFF
--- a/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
+++ b/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
@@ -76,6 +76,7 @@ class WidgetBuilderCoordinator: Coordinator {
         
         if injectedConfiguration != nil {
             viewController.loadDataFromContent(contentBuilder.build())
+            viewController.navigationItem.title = .localized(for: .widgetEditingNavigationTitle)
         }
         
         viewController.hidesBottomBarWhenPushed = true
@@ -102,6 +103,7 @@ extension WidgetBuilderCoordinator: WidgetSetupViewControllerDelegate {
         
         if injectedConfiguration != nil {
             viewController.loadDataFromBuilder(configurationBuilder)
+            viewController.navigationItem.title = .localized(for: .widgetEditingNavigationTitle)
         }
         
         router.present(viewController, animated: true)

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -383,6 +383,17 @@
     "Widget Configuration" : {
 
     },
+    "widgetEditingNavigationTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editing"
+          }
+        }
+      }
+    },
     "widgetEditorViewSaveWidgetButton" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modulite/Localization/String+LocalizedKey.swift
+++ b/Modulite/Localization/String+LocalizedKey.swift
@@ -112,6 +112,8 @@ extension String {
         case widgetSetupViewSearchAppsButtonTitle
         case widgetSetupViewSearchAppsHelperText
         
+        case widgetEditingNavigationTitle
+        
         // MARK: - SearchAppsView
         case selectAppsViewTitle
         case selectAppsViewSubtitle

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
@@ -95,7 +95,7 @@ class WidgetEditorView: UIScrollView {
             .localized(for: .widgetEditorViewWallpaperButton),
             attributes: AttributeContainer([
                 .font: UIFont(textStyle: .body, weight: .bold),
-                .foregroundColor: UIColor.black
+                .foregroundColor: UIColor.textPrimary
             ])
         )
         
@@ -130,7 +130,7 @@ class WidgetEditorView: UIScrollView {
                         .localized(for: .widgetEditorViewWallpaperButtonSaved),
                         attributes: AttributeContainer([
                             .font: UIFont(textStyle: .body, weight: .bold),
-                            .foregroundColor: UIColor.black
+                            .foregroundColor: UIColor.textPrimary
                         ])
                     )
                     


### PR DESCRIPTION
## Issue Reference

This PR closes #87 by implementing a navigation title for the views related to widget editing, improving the navigation context within the app.

## Summary

The following key changes have been made:

1. **Added Navigation Titles for Widget Editing Views**: Implemented navigation titles for the views in the widget editing flow. This provides better context for the user when they are editing a widget, making the experience more intuitive and aligned with standard navigation patterns.
   
2. **Back Button Displays "Editing"**: The back button in `WidgetEditorViewController` now displays the text **"Editing"**, which informs the user that they are returning from an editing screen. However, further evaluation is needed to determine if this is the most appropriate text for the context, as it may not fully reflect the intent of the navigation flow.

## Known Considerations

- **Evaluation of Navigation Titles**: While the navigation titles have been implemented, additional feedback is required to determine if they are the best fit for the editing views. Specifically, the use of **"Editing"** on the back button might not provide the most accurate description of the flow, and adjustments may be needed based on user experience testing.

## Next Steps

- Review and gather feedback on the navigation titles, particularly for the back button text ("Editing"), to determine if adjustments are necessary.
- Consider potential alternatives for the back button text that better reflect the action or screen the user is navigating from.