### PR TITLE
Main Widgets Now Start Editing Flow

### DIFF
--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -236,8 +236,14 @@ extension HomeViewController: UICollectionViewDataSource {
 
 // MARK: - UICollectionViewDelegate
 extension HomeViewController: UICollectionViewDelegate {
-    // TODO: Implement cell selection
-    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch collectionView {
+        case homeView.mainWidgetsCollectionView:
+            delegate?.homeViewControllerDidStartWidgetEditingFlow(self, widget: viewModel.mainWidgets[indexPath.row])
+        default:
+            return
+        }
+    }
 }
 
 // MARK: - MainWidgetCollectionViewCellDelegate


### PR DESCRIPTION
## Issue Reference

This PR closes #51, implementing the functionality where tapping on a widget cell in the Home View triggers the widget editing flow.

## Summary

The following changes have been made:

1. **Widget Cell Taps Initiate Editing Flow**: Tapping on a widget cell in the `HomeView` now correctly initializes the widget editing flow, allowing users to quickly access and modify their widgets from the home screen.

## Future Considerations

- **Additional Cell Types**: This implementation is currently limited to widget cells. As other types of cells, such as auxiliary widgets and tips, are added in the future, separate methods will need to be implemented to handle their specific interactions.

## Testing

- Verified that tapping on a widget cell in the `HomeView` successfully initiates the widget editing process.
- Ensured that the editing flow functions as expected once initiated from the home screen.

This is a straightforward PR that sets the groundwork for future interactions with other types of cells in the Home View.