### PR TITLE
Implement App Deselection Through `WidgetSetupView`

### DIFF
--- a/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
+++ b/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
@@ -134,6 +134,13 @@ extension WidgetBuilderCoordinator: WidgetSetupViewControllerDelegate {
             )
         }
     }
+    
+    func widgetSetupViewControllerDidDeselectApp(
+        _ controller: WidgetSetupViewController,
+        app: AppInfo
+    ) {
+        contentBuilder.removeApp(app)
+    }
 }
 
 // MARK: - SelectAppsViewControllerDelegate

--- a/Modulite/Screens/WidgetConfiguration/Setup/View/CollectionViewCells/SelectedAppCollectionViewCell.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/CollectionViewCells/SelectedAppCollectionViewCell.swift
@@ -8,10 +8,16 @@
 import UIKit
 import SnapKit
 
+protocol SelectedAppCollectionViewCellDelegate: AnyObject {
+    func selectedAppCollectionViewCellDidPressDelete(_ cell: SelectedAppCollectionViewCell)
+}
+
 class SelectedAppCollectionViewCell: UICollectionViewCell {
     static let reuseId = "SelectedAppCollectionViewCell"
     
     // MARK: - Properties
+    
+    weak var delegate: SelectedAppCollectionViewCellDelegate?
     
     private(set) lazy var nameLabel: UILabel = {
         let view = UILabel()
@@ -34,6 +40,26 @@ class SelectedAppCollectionViewCell: UICollectionViewCell {
         )
         
         let view = UIButton(configuration: config)
+        view.addTarget(self, action: #selector(handleDeleteTouch), for: .touchUpInside)
+        
+        view.configurationUpdateHandler = { [weak self] button in
+            guard let self = self else { return }
+            UIView.animate(withDuration: 0.1) {
+                var config = button.configuration
+                
+                switch button.state {
+                case .highlighted:
+                    self.animateBorderColor(toColor: .red, duration: 0.25)
+                    button.alpha = 0.5
+                    self.transform = .init(scaleX: 0.97, y: 0.97)
+                    
+                default:
+                    self.animateBorderColor(toColor: .carrotOrange, duration: 0.25)
+                    button.alpha = 1
+                    self.transform = .init(scaleX: 1, y: 1)
+                }
+            }
+        }
         
         return view
     }()
@@ -69,5 +95,12 @@ class SelectedAppCollectionViewCell: UICollectionViewCell {
             make.left.equalTo(nameLabel.snp.right).offset(10)
             make.right.equalToSuperview().inset(12)
         }
+    }
+    
+    // MARK: - Actions
+    
+    @objc
+    private func handleDeleteTouch() {
+        delegate?.selectedAppCollectionViewCellDidPressDelete(self)
     }
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #94, implementing the functionality to deselect apps by clicking the "X" button in the **Widget Setup View** using delegates.

## Summary

The following key changes have been made:

1. **Deselect Apps by Clicking "X"**: Implemented the ability for users to deselect apps in the `WidgetSetupView` by clicking the "X" button next to each app. This feature improves the user experience by providing a simple and intuitive way to remove selected apps from the widget configuration.
   
2. **Delegate Pattern for Communication**: The deselection functionality is managed through a **delegate pattern**, ensuring that the view communicates back to the view controller when an app is deselected. This keeps the code modular and the view controller in control of the widget setup logic.

3. **UI Updates**: After an app is deselected, the UI is updated in real-time to reflect the change, removing the app from the list of selected apps.

## Testing

- Verified that clicking the "X" button successfully deselects the corresponding app.
- Ensured that the delegate method is triggered correctly when an app is deselected.
- Confirmed that the UI updates as expected, removing the app from the selected list.
- Tested the functionality with multiple apps to ensure consistent behavior.