### PR TITLE
Fixed Duplicates when Widget is Updated

### DIFF
--- a/Modulite/Builders/WidgetConfigurationBuilder.swift
+++ b/Modulite/Builders/WidgetConfigurationBuilder.swift
@@ -43,6 +43,8 @@ class WidgetConfigurationBuilder {
     init(content: WidgetContent, configuration: ModuliteWidgetConfiguration) {
         widgetContent = content
         self.configuration = configuration
+        self.configuration.name = content.name
+        self.configuration.widgetStyle = content.style
     }
     
     // MARK: - Getters

--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -58,7 +58,6 @@ extension HomeCoordinator: HomeViewControllerDelegate {
         )
         
         coordinator.onWidgetSave = { widget in
-            CoreDataPersistenceController.shared.updateWidget(widget)
             viewController.updateMainWidget(widget)
             WidgetCenter.shared.reloadAllTimelines()
         }

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
@@ -107,7 +107,7 @@ class WidgetEditorViewModel: NSObject {
     @discardableResult
     func saveWidget(from collectionView: UICollectionView) -> ModuliteWidgetConfiguration {
         let widgetConfiguration = builder.build()
-        let persistedConfig = CoreDataPersistenceController.shared.registerWidget(
+        let persistedConfig = CoreDataPersistenceController.shared.registerOrUpdateWidget(
             widgetConfiguration,
             widgetImage: collectionView.asImage()
         )


### PR DESCRIPTION
## Issue Reference

This PR closes #91, fixing a bug where duplicate entries were being created in Core Data when the user attempted to update an existing widget.

## Summary

The following changes were made to address the issue:

1. **Fixed Duplicate Persistence in Core Data**: Resolved a bug where Core Data was creating duplicate entries when users updated an existing widget. The issue was caused by the way Core Data handled widget creation during updates.
   
2. **Unified Creation and Update Logic**: Refactored the logic so that the same method now handles both **widget creation** and **widget updates**. This ensures that when a widget is updated, the existing entry is modified instead of creating a duplicate. This approach leverages the same Core Data transaction for both actions, eliminating the duplication issue.

## Testing

- Verified that updating an existing widget no longer creates a duplicate entry in Core Data.
- Confirmed that new widgets are created correctly, and updates modify the existing records as expected.
- Tested the functionality across different widget configurations to ensure consistent behavior without any duplication.

## Next Steps

- Monitor for any additional edge cases where duplication might occur in other parts of the app.
- Continue testing widget creation and update workflows to ensure no regression in Core Data persistence.