### PR TITLE
Delete Button in `WidgetEditorView`

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -155,6 +155,9 @@
 		B3987E322CA4F48C00896414 /* MainWidgetConfigurationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3987E302CA4F48C00896414 /* MainWidgetConfigurationEntity.swift */; };
 		B39A259D2CAB2945001C76A5 /* Copying.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A259C2CAB2945001C76A5 /* Copying.swift */; };
 		B39A259E2CAB2969001C76A5 /* Copying.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A259C2CAB2945001C76A5 /* Copying.swift */; };
+		B39A25A22CAB5B65001C76A5 /* WidgetEditorDownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25A12CAB5B65001C76A5 /* WidgetEditorDownloadButton.swift */; };
+		B39A25A42CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25A32CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift */; };
+		B39A25A62CAB5F11001C76A5 /* WidgetEditorDeleteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25A52CAB5F11001C76A5 /* WidgetEditorDeleteButton.swift */; };
 		B3C1877F2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C1877E2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift */; };
 		B3C187822C79009B00A891A8 /* WidgetConfigurationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C187812C79009B00A891A8 /* WidgetConfigurationBuilder.swift */; };
 		B3C187842C791D1300A891A8 /* WidgetStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C187832C791D1300A891A8 /* WidgetStyle.swift */; };
@@ -324,6 +327,9 @@
 		B3987E2D2CA4F46A00896414 /* MainWidgetConfigurationQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWidgetConfigurationQuery.swift; sourceTree = "<group>"; };
 		B3987E302CA4F48C00896414 /* MainWidgetConfigurationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWidgetConfigurationEntity.swift; sourceTree = "<group>"; };
 		B39A259C2CAB2945001C76A5 /* Copying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Copying.swift; sourceTree = "<group>"; };
+		B39A25A12CAB5B65001C76A5 /* WidgetEditorDownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEditorDownloadButton.swift; sourceTree = "<group>"; };
+		B39A25A32CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEditorSaveButton.swift; sourceTree = "<group>"; };
+		B39A25A52CAB5F11001C76A5 /* WidgetEditorDeleteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEditorDeleteButton.swift; sourceTree = "<group>"; };
 		B3C1877E2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuliteWidgetConfiguration.swift; sourceTree = "<group>"; };
 		B3C187812C79009B00A891A8 /* WidgetConfigurationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetConfigurationBuilder.swift; sourceTree = "<group>"; };
 		B3C187832C791D1300A891A8 /* WidgetStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStyle.swift; sourceTree = "<group>"; };
@@ -635,9 +641,10 @@
 		B350C04F2C8B90860035682F /* View */ = {
 			isa = PBXGroup;
 			children = (
-				B34F3E3C2C74CD160041D7BD /* CollectionViewCells */,
-				B34F3E232C6D366A0041D7BD /* WidgetEditorView.swift */,
 				B34F3E3D2C74CE090041D7BD /* EditorSectionHeader.swift */,
+				B34F3E232C6D366A0041D7BD /* WidgetEditorView.swift */,
+				B34F3E3C2C74CD160041D7BD /* CollectionViewCells */,
+				B39A25A02CAB5B3F001C76A5 /* Subviews */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -980,6 +987,16 @@
 			path = Prototype;
 			sourceTree = "<group>";
 		};
+		B39A25A02CAB5B3F001C76A5 /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				B39A25A12CAB5B65001C76A5 /* WidgetEditorDownloadButton.swift */,
+				B39A25A32CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift */,
+				B39A25A52CAB5F11001C76A5 /* WidgetEditorDeleteButton.swift */,
+			);
+			path = Subviews;
+			sourceTree = "<group>";
+		};
 		B3C187802C79008800A891A8 /* Builders */ = {
 			isa = PBXGroup;
 			children = (
@@ -1290,6 +1307,7 @@
 				B350C0472C8B8B340035682F /* UILabel+Padded.swift in Sources */,
 				B3850BB72C951DD700F400C0 /* WidgetBackground.swift in Sources */,
 				B32B60C72C865042007DDCE3 /* PersistableWidgetConfiguration+CoreDataProperties.swift in Sources */,
+				B39A25A62CAB5F11001C76A5 /* WidgetEditorDeleteButton.swift in Sources */,
 				B34F3E1A2C6B94080041D7BD /* HomeHeaderReusableCell.swift in Sources */,
 				B36927CF2C66B8A30089F769 /* Coordinator.swift in Sources */,
 				B32B60BA2C864807007DDCE3 /* PersistableModuleConfiguration+CoreDataClass.swift in Sources */,
@@ -1311,6 +1329,7 @@
 				AFBBC5212C7E4E0700A9B256 /* WidgetButtonLabelView.swift in Sources */,
 				AFBBC51E2C7E4C8500A9B256 /* WidgetButtonView.swift in Sources */,
 				B3CDD7032C767FD300E558F8 /* ModuleColorCell.swift in Sources */,
+				B39A25A42CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift in Sources */,
 				B32B60F02C876F4A007DDCE3 /* FileManagerImagePersistenceController.swift in Sources */,
 				B3EB15B92C7E4CD6003B1960 /* ModuleAppNameTextConfiguration.swift in Sources */,
 				B3EB15B62C7E4BF0003B1960 /* ModuleConfiguration.swift in Sources */,
@@ -1334,6 +1353,7 @@
 				B34F3E352C6E93570041D7BD /* WidgetSetupViewModel.swift in Sources */,
 				B34F3DF82C69A3810041D7BD /* DebugOptions.swift in Sources */,
 				B32B60BF2C864AD9007DDCE3 /* PersistableModuleConfiguration+CoreDataProperties.swift in Sources */,
+				B39A25A22CAB5B65001C76A5 /* WidgetEditorDownloadButton.swift in Sources */,
 				B32B61032C88EE1E007DDCE3 /* WidgetSetupAppsTagFlowLayout.swift in Sources */,
 				B3987E2B2CA4F43100896414 /* SelectMainWidgetConfigurationIntent.swift in Sources */,
 				B34F3E052C6A93AC0041D7BD /* SettingsViewController.swift in Sources */,

--- a/Modulite/Assets.xcassets/Colors/blueberry.colorset/Contents.json
+++ b/Modulite/Assets.xcassets/Colors/blueberry.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5F",
+          "green" : "0x4B",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7C",
+          "green" : "0x67",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Modulite/Assets.xcassets/Colors/figBlue.colorset/Contents.json
+++ b/Modulite/Assets.xcassets/Colors/figBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x78",
+          "green" : "0x6B",
+          "red" : "0x4B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x82",
+          "green" : "0x7B",
+          "red" : "0x68"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Modulite/Assets.xcassets/Colors/ketchupRed.colorset/Contents.json
+++ b/Modulite/Assets.xcassets/Colors/ketchupRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x38",
+          "green" : "0x45",
+          "red" : "0xC6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Modulite/Builders/WidgetConfigurationBuilder.swift
+++ b/Modulite/Builders/WidgetConfigurationBuilder.swift
@@ -48,6 +48,10 @@ class WidgetConfigurationBuilder {
     }
     
     // MARK: - Getters
+    func getWidgetId() -> UUID {
+        configuration.id
+    }
+    
     func getStyleWallpapers() -> (blocked: UIImage, home: UIImage) {
         (widgetContent.style.blockedScreenWallpaperImage, widgetContent.style.homeScreenWallpaperImage)
     }

--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -64,6 +64,11 @@ extension HomeCoordinator: HomeViewControllerDelegate {
             WidgetCenter.shared.reloadAllTimelines()
         }
         
+        coordinator.onWidgetDelete = { widgetId in
+            viewController.deleteMainWidget(with: widgetId)
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+        
         presentChild(coordinator, animated: true)
     }
 }

--- a/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
+++ b/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
@@ -31,6 +31,7 @@ class WidgetBuilderCoordinator: Coordinator {
     var currentWidgetCount: Int
     
     var onWidgetSave: ((ModuliteWidgetConfiguration) -> Void)?
+    var onWidgetDelete: ((UUID) -> Void)?
     
     var injectedConfiguration: ModuliteWidgetConfiguration?
     
@@ -75,8 +76,10 @@ class WidgetBuilderCoordinator: Coordinator {
         let viewController = WidgetSetupViewController.instantiate(delegate: self)
         
         if injectedConfiguration != nil {
-            viewController.loadDataFromContent(contentBuilder.build())
             viewController.navigationItem.title = .localized(for: .widgetEditingNavigationTitle)
+            viewController.loadDataFromContent(contentBuilder.build())
+            // this will make save button appear, whose behavior is not working
+            // viewController.setIsEditingViewToTrue()
         }
         
         viewController.hidesBottomBarWhenPushed = true
@@ -104,6 +107,7 @@ extension WidgetBuilderCoordinator: WidgetSetupViewControllerDelegate {
         if injectedConfiguration != nil {
             viewController.loadDataFromBuilder(configurationBuilder)
             viewController.navigationItem.title = .localized(for: .widgetEditingNavigationTitle)
+            viewController.setIsEditingViewToTrue()
         }
         
         router.present(viewController, animated: true)
@@ -164,6 +168,12 @@ extension WidgetBuilderCoordinator: WidgetSetupViewControllerDelegate {
             )
         )
     }
+    
+    func widgetSetupViewControllerDidSaveWidget(
+        _ viewController: WidgetSetupViewController
+    ) {
+        // won't fix this for now
+    }
 }
 
 // MARK: - SelectAppsViewControllerDelegate
@@ -221,6 +231,14 @@ extension WidgetBuilderCoordinator: WidgetEditorViewControllerDelegate {
         didSave widget: ModuliteWidgetConfiguration
     ) {
         onWidgetSave?(widget)
+        dismiss(animated: true)
+    }
+    
+    func widgetEditorViewController(
+        _ viewController: WidgetEditorViewController,
+        didDeleteWithId id: UUID
+    ) {
+        onWidgetDelete?(id)
         dismiss(animated: true)
     }
 }

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -394,6 +394,28 @@
         }
       }
     },
+    "widgetEditorViewDeleteAlertMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to delete this widget? This action cannot be undone."
+          }
+        }
+      }
+    },
+    "widgetEditorViewDeleteAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete this widget?"
+          }
+        }
+      }
+    },
     "widgetEditorViewSaveWidgetButton" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modulite/Localization/String+LocalizedKey.swift
+++ b/Modulite/Localization/String+LocalizedKey.swift
@@ -127,6 +127,8 @@ extension String {
         case widgetEditorViewWallpaperButton
         case widgetEditorViewWallpaperButtonSaved
         case widgetEditorViewSaveWidgetButton
+        case widgetEditorViewDeleteAlertTitle
+        case widgetEditorViewDeleteAlertMessage
         
         // MARK: - UsageView & UsageViewController
         case usageViewYouHaveSpent

--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -96,6 +96,15 @@ class HomeViewController: UIViewController {
         }
     }
     
+    func deleteMainWidget(with id: UUID) {
+        guard let widget = viewModel.mainWidgets.first(where: { $0.id == id }) else {
+            print("Widget with id \(id) not found in view model.")
+            return
+        }
+        
+        deleteWidget(widget)
+    }
+    
     func deleteWidget(_ widget: ModuliteWidgetConfiguration) {
         guard let index = viewModel.getIndexFor(widget) else {
             print("Widget not found in data source.")

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDeleteButton.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDeleteButton.swift
@@ -1,0 +1,47 @@
+//
+//  WidgetEditorDeleteButton.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 30/09/24.
+//
+
+import UIKit
+
+class WidgetEditorDeleteButton: UIButton {
+    
+    // MARK: - Initializers
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupButton()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupButton()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupButton() {
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = .ketchupRed
+        
+        config.attributedTitle = AttributedString(
+            .localized(for: .delete).uppercased(),
+            attributes: AttributeContainer([
+                .font: UIFont(textStyle: .body, weight: .bold),
+                .foregroundColor: UIColor.white
+            ])
+        )
+        
+        config.imagePlacement = .leading
+        config.image = UIImage(systemName: "trash")
+        config.imagePadding = 10
+        config.preferredSymbolConfigurationForImage = .init(pointSize: 15, weight: .bold)
+        config.baseForegroundColor = .white
+        
+        configuration = config
+        layer.cornerRadius = 0
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDownloadButton.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDownloadButton.swift
@@ -1,0 +1,81 @@
+//
+//  WidgetEditorDownloadButton.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 30/09/24.
+//
+
+import UIKit
+
+class WidgetEditorDownloadButton: UIButton {
+    
+    // MARK: - Initializers
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupButton()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupButton()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupButton() {
+        var config = UIButton.Configuration.bordered()
+        
+        config.attributedTitle = AttributedString(
+            .localized(for: .widgetEditorViewWallpaperButton),
+            attributes: AttributeContainer([
+                .font: UIFont(textStyle: .body, weight: .bold),
+                .foregroundColor: UIColor.textPrimary
+            ])
+        )
+        
+        config.titleAlignment = .center
+        config.titleLineBreakMode = .byClipping
+        
+        config.image = UIImage(systemName: "square.and.arrow.down")?
+            .withTintColor(.black, renderingMode: .alwaysOriginal)
+        
+        config.imagePlacement = .leading
+        config.imagePadding = 5
+        
+        config.baseBackgroundColor = .clear
+        
+        configuration = config
+        
+        layer.borderColor = UIColor.carrotOrange.cgColor
+        layer.borderWidth = 2
+        
+        configurationUpdateHandler = { button in
+            var updatedConfig = button.configuration
+            
+            UIView.animate(withDuration: 0.1) {
+                switch button.state {
+                case .highlighted:
+                    button.alpha = 0.67
+                    button.transform = CGAffineTransform(scaleX: 0.97, y: 0.97)
+                    
+                case .disabled:
+                    button.alpha = 0.67
+                    button.layer.borderColor = UIColor.gray.cgColor
+                    updatedConfig?.attributedTitle = AttributedString(
+                        .localized(for: .widgetEditorViewWallpaperButtonSaved),
+                        attributes: AttributeContainer([
+                            .font: UIFont(textStyle: .body, weight: .bold),
+                            .foregroundColor: UIColor.textPrimary
+                        ])
+                    )
+                    button.configuration = updatedConfig
+                    
+                default:
+                    button.alpha = 1
+                    button.transform = .identity
+                }
+            }
+        }
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorSaveButton.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorSaveButton.swift
@@ -1,0 +1,61 @@
+//
+//  WidgetEditorSaveButton.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 30/09/24.
+//
+
+import UIKit
+
+class WidgetEditorSaveButton: UIButton {
+    
+    // MARK: - Initializers
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupButton()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupButton()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupButton() {
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = .fiestaGreen
+        
+        config.attributedTitle = AttributedString(
+            .localized(for: .widgetEditorViewSaveWidgetButton),
+            attributes: AttributeContainer([
+                .font: UIFont(textStyle: .body, weight: .bold),
+                .foregroundColor: UIColor.white
+            ])
+        )
+        
+        config.imagePlacement = .leading
+        config.image = UIImage(systemName: "envelope")
+        config.imagePadding = 10
+        config.preferredSymbolConfigurationForImage = .init(pointSize: 15, weight: .bold)
+        config.baseForegroundColor = .white
+        
+        self.configuration = config
+        self.layer.cornerRadius = 0
+    }
+    
+    // MARK: - Appereance updating
+    
+    func setToEditingState() {
+        var config = self.configuration
+        config?.attributedTitle = AttributedString(
+            .localized(for: .save).uppercased(),
+            attributes: AttributeContainer([
+                .font: UIFont(textStyle: .body, weight: .bold),
+                .foregroundColor: UIColor.white
+            ])
+        )
+        self.configuration = config
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
@@ -28,6 +28,10 @@ class WidgetEditorViewModel: NSObject {
     
     // MARK: - Getters
     
+    func getWidgetId() -> UUID {
+        builder.getWidgetId()
+    }
+    
     func getWidgetBackground() -> WidgetBackground? {
         builder.getStyleBackground()
     }

--- a/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
@@ -12,8 +12,15 @@ class WidgetSetupView: UIScrollView {
     
     // MARK: - Properties
     
+    private var isEditing: Bool = false {
+        didSet {
+            saveWidgetButton.isHidden = !isEditing
+        }
+    }
+    
     var onSearchButtonPressed: (() -> Void)?
     var onNextButtonPressed: (() -> Void)?
+    var onSaveButtonPressed: (() -> Void)?
     
     var isStyleSelected = false
     var hasAppsSelected = false
@@ -99,7 +106,7 @@ class WidgetSetupView: UIScrollView {
     
     private(set) lazy var nextViewButton: UIButton = {
         var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = .fiestaGreen
+        config.baseBackgroundColor = .blueberry
         config.title = .localized(for: .next)
         config.imagePlacement = .trailing
         config.image = UIImage(systemName: "arrow.right")
@@ -110,6 +117,40 @@ class WidgetSetupView: UIScrollView {
         let view = UIButton(configuration: config)
         
         view.addTarget(self, action: #selector(handleNextButtonPressed), for: .touchUpInside)
+        view.configurationUpdateHandler = { [weak self] btn in
+            guard let self = self, var config = btn.configuration else { return }
+            
+            btn.isEnabled = self.isStyleSelected && self.hasAppsSelected
+            
+            switch btn.state {
+            case .disabled:
+                config.background.backgroundColor = .systemGray2
+                
+            default:
+                config.background.backgroundColor = .blueberry
+            }
+            
+            btn.configuration = config
+        }
+        
+        return view
+    }()
+    
+    private(set) lazy var saveWidgetButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = .fiestaGreen
+        config.title = .localized(for: .save).uppercased()
+        config.imagePlacement = .leading
+        config.image = UIImage(systemName: "envelope")
+        config.imagePadding = 10
+        config.preferredSymbolConfigurationForImage = .init(pointSize: 20, weight: .bold)
+        config.baseForegroundColor = .white
+        
+        let view = UIButton(configuration: config)
+        
+        view.isHidden = true
+        
+        view.addTarget(self, action: #selector(handleSaveButtonPressed), for: .touchUpInside)
         view.configurationUpdateHandler = { [weak self] btn in
             guard let self = self, var config = btn.configuration else { return }
             
@@ -154,6 +195,10 @@ class WidgetSetupView: UIScrollView {
         onNextButtonPressed?()
     }
     
+    @objc private func handleSaveButtonPressed() {
+        onSaveButtonPressed?()
+    }
+    
     // MARK: - Initializers
     
     override init(frame: CGRect) {
@@ -172,6 +217,10 @@ class WidgetSetupView: UIScrollView {
     }
     
     // MARK: - Setup methods
+    
+    func setEditingMode(to value: Bool) {
+        isEditing = value
+    }
     
     func updateSelectedAppsCollectionViewHeight() {
         selectedAppsCollectionView.snp.updateConstraints { make in
@@ -224,6 +273,10 @@ class WidgetSetupView: UIScrollView {
         )
     }
     
+    private func updateSaveButtonVisibility() {
+        
+    }
+    
     private func addSubviews() {
         addSubview(contentView)
         contentView.addSubview(widgetNameTextField)
@@ -233,6 +286,8 @@ class WidgetSetupView: UIScrollView {
         contentView.addSubview(selectedAppsCollectionView)
         contentView.addSubview(searchAppsHelperText)
         contentView.addSubview(nextViewButton)
+                
+        contentView.addSubview(saveWidgetButton)
     }
     
     private func setupConstraints() {
@@ -281,9 +336,14 @@ class WidgetSetupView: UIScrollView {
         
         nextViewButton.snp.makeConstraints { make in
             make.right.equalToSuperview()
-            make.width.equalTo(130)
+            make.width.equalTo(160)
             make.height.equalTo(45)
             make.bottom.equalToSuperview()
+        }
+                
+        saveWidgetButton.snp.makeConstraints { make in
+            make.height.bottom.width.equalTo(nextViewButton)
+            make.right.equalTo(nextViewButton.snp.left).offset(-32)
         }
     }
 }

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
@@ -25,6 +25,10 @@ protocol WidgetSetupViewControllerDelegate: AnyObject {
         _ controller: WidgetSetupViewController,
         style: WidgetStyle
     )
+    
+    func widgetSetupViewControllerDidSaveWidget(
+        _ viewController: WidgetSetupViewController
+    )
 }
 
 class WidgetSetupViewController: UIViewController {
@@ -52,6 +56,10 @@ class WidgetSetupViewController: UIViewController {
     }
     
     // MARK: - Setup methods
+    func setIsEditingViewToTrue() {
+        setupView.setEditingMode(to: true)
+    }
+    
     private func configureViewDependencies() {
         setupView.setCollectionViewDelegates(to: self)
         setupView.setCollectionViewDataSources(to: self)
@@ -59,6 +67,7 @@ class WidgetSetupViewController: UIViewController {
         
         setupView.onNextButtonPressed = proceedToWidgetEditor
         setupView.onSearchButtonPressed = presentSearchModal
+        setupView.onSaveButtonPressed = handleSaveButtonPress
     }
     
     private func setPlaceholderName(to name: String) {
@@ -66,6 +75,10 @@ class WidgetSetupViewController: UIViewController {
     }
     
     // MARK: - Actions
+    func handleSaveButtonPress() {
+        delegate?.widgetSetupViewControllerDidSaveWidget(self)
+    }
+    
     func didFinishSelectingApps(apps: [AppInfo]) {
         setSetupViewHasAppsSelected(to: !apps.isEmpty)
         viewModel.setSelectedApps(to: apps)

--- a/ModuliteWidget/Assets.xcassets/Colors/blueberry.colorset/Contents.json
+++ b/ModuliteWidget/Assets.xcassets/Colors/blueberry.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5F",
+          "green" : "0x4B",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7C",
+          "green" : "0x67",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteWidget/Assets.xcassets/Colors/figBlue.colorset/Contents.json
+++ b/ModuliteWidget/Assets.xcassets/Colors/figBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x78",
+          "green" : "0x6B",
+          "red" : "0x4B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x82",
+          "green" : "0x7B",
+          "red" : "0x68"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Issue Reference

This PR closes #70, implementing the delete button at the end of the widget editing flow and addressing save button logic.

## Summary

1. **Delete Button in Widget Editor**: Implemented a **delete button** that allows users to delete a widget at the end of the widget editing flow. This button provides a clear and direct option for users who wish to remove a widget from their setup.
   
2. **Save Button in `WidgetSetupView`**: A **save button** was also added to the `WidgetSetupView`, but this functionality will be discontinued. After reviewing the widget saving process, it became evident that widget saving needs to occur in the `WidgetEditorView`. This is because saving a widget requires capturing the collection view as an image to generate its preview, which is not feasible in the `WidgetSetupView`.

## Known Considerations

- The save button logic in the `WidgetSetupView` has been paused for now, as the current structure dictates that the saving functionality belongs in the `WidgetEditorView` for proper image generation and preview setup.

## Testing

- Verified that the delete button correctly removes the widget and prompts the user with an alert for confirmation.
- Confirmed that the `WidgetEditorView` handles widget deletions as expected.
- Tested the temporary save button in `WidgetSetupView` but confirmed that further work will focus on the `WidgetEditorView` for final saving.