### PR TITLE
Widget Editing Alerts For Unsaved Changes

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -158,6 +158,9 @@
 		B39A25A22CAB5B65001C76A5 /* WidgetEditorDownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25A12CAB5B65001C76A5 /* WidgetEditorDownloadButton.swift */; };
 		B39A25A42CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25A32CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift */; };
 		B39A25A62CAB5F11001C76A5 /* WidgetEditorDeleteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25A52CAB5F11001C76A5 /* WidgetEditorDeleteButton.swift */; };
+		B39A25AA2CAC7C89001C76A5 /* WidgetEditorViewController+UICollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25A92CAC7C89001C76A5 /* WidgetEditorViewController+UICollectionViewDataSource.swift */; };
+		B39A25AC2CAC7D2A001C76A5 /* WidgetEditorViewController+UICollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25AB2CAC7D2A001C76A5 /* WidgetEditorViewController+UICollectionViewDelegate.swift */; };
+		B39A25AE2CAC7DC2001C76A5 /* WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A25AD2CAC7DC2001C76A5 /* WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift */; };
 		B3C1877F2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C1877E2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift */; };
 		B3C187822C79009B00A891A8 /* WidgetConfigurationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C187812C79009B00A891A8 /* WidgetConfigurationBuilder.swift */; };
 		B3C187842C791D1300A891A8 /* WidgetStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C187832C791D1300A891A8 /* WidgetStyle.swift */; };
@@ -330,6 +333,9 @@
 		B39A25A12CAB5B65001C76A5 /* WidgetEditorDownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEditorDownloadButton.swift; sourceTree = "<group>"; };
 		B39A25A32CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEditorSaveButton.swift; sourceTree = "<group>"; };
 		B39A25A52CAB5F11001C76A5 /* WidgetEditorDeleteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEditorDeleteButton.swift; sourceTree = "<group>"; };
+		B39A25A92CAC7C89001C76A5 /* WidgetEditorViewController+UICollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetEditorViewController+UICollectionViewDataSource.swift"; sourceTree = "<group>"; };
+		B39A25AB2CAC7D2A001C76A5 /* WidgetEditorViewController+UICollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetEditorViewController+UICollectionViewDelegate.swift"; sourceTree = "<group>"; };
+		B39A25AD2CAC7DC2001C76A5 /* WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift"; sourceTree = "<group>"; };
 		B3C1877E2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuliteWidgetConfiguration.swift; sourceTree = "<group>"; };
 		B3C187812C79009B00A891A8 /* WidgetConfigurationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetConfigurationBuilder.swift; sourceTree = "<group>"; };
 		B3C187832C791D1300A891A8 /* WidgetStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStyle.swift; sourceTree = "<group>"; };
@@ -633,6 +639,7 @@
 		B350C04E2C8B907B0035682F /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				B39A25A82CAC7C5B001C76A5 /* Extensions */,
 				B34F3E212C6D36390041D7BD /* WidgetEditorViewController.swift */,
 			);
 			path = ViewController;
@@ -997,6 +1004,16 @@
 			path = Subviews;
 			sourceTree = "<group>";
 		};
+		B39A25A82CAC7C5B001C76A5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B39A25A92CAC7C89001C76A5 /* WidgetEditorViewController+UICollectionViewDataSource.swift */,
+				B39A25AB2CAC7D2A001C76A5 /* WidgetEditorViewController+UICollectionViewDelegate.swift */,
+				B39A25AD2CAC7DC2001C76A5 /* WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		B3C187802C79008800A891A8 /* Builders */ = {
 			isa = PBXGroup;
 			children = (
@@ -1301,6 +1318,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B39A25AE2CAC7DC2001C76A5 /* WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift in Sources */,
 				B34F3E0F2C6B0D340041D7BD /* BlockAppsCoordinator.swift in Sources */,
 				B39A259D2CAB2945001C76A5 /* Copying.swift in Sources */,
 				B32B60C62C865042007DDCE3 /* PersistableWidgetConfiguration+CoreDataClass.swift in Sources */,
@@ -1332,6 +1350,7 @@
 				B39A25A42CAB5CE3001C76A5 /* WidgetEditorSaveButton.swift in Sources */,
 				B32B60F02C876F4A007DDCE3 /* FileManagerImagePersistenceController.swift in Sources */,
 				B3EB15B92C7E4CD6003B1960 /* ModuleAppNameTextConfiguration.swift in Sources */,
+				B39A25AC2CAC7D2A001C76A5 /* WidgetEditorViewController+UICollectionViewDelegate.swift in Sources */,
 				B3EB15B62C7E4BF0003B1960 /* ModuleConfiguration.swift in Sources */,
 				AFABBD982C8A359E007BEFD8 /* BlockAppsView.swift in Sources */,
 				B36927D32C66BBC10089F769 /* SceneDelegateRouter.swift in Sources */,
@@ -1340,6 +1359,7 @@
 				B3C187822C79009B00A891A8 /* WidgetConfigurationBuilder.swift in Sources */,
 				B3C1877F2C78D1E000A891A8 /* ModuliteWidgetConfiguration.swift in Sources */,
 				B32B60FE2C88E43F007DDCE3 /* CustomizedTextFactory.swift in Sources */,
+				B39A25AA2CAC7C89001C76A5 /* WidgetEditorViewController+UICollectionViewDataSource.swift in Sources */,
 				B34F3E3E2C74CE090041D7BD /* EditorSectionHeader.swift in Sources */,
 				B34F3DFD2C6A92890041D7BD /* RootTabBarController.swift in Sources */,
 				B350C0492C8B8B680035682F /* UIEdgeInsets+Directions.swift in Sources */,

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -4,6 +4,17 @@
     "%@" : {
 
     },
+    "back" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
+          }
+        }
+      }
+    },
     "blockAppsViewBlockingSession" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -383,6 +394,17 @@
     "Widget Configuration" : {
 
     },
+    "widgetCreatingUnsavedChangesAlertMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have unsaved alterations.  If you want to save them press ”Keep editing” > Save Widget"
+          }
+        }
+      }
+    },
     "widgetEditingNavigationTitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -390,6 +412,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Editing"
+          }
+        }
+      }
+    },
+    "widgetEditingUnsavedChangesAlertActionDiscard" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discard Changes"
+          }
+        }
+      }
+    },
+    "widgetEditingUnsavedChangesAlertActionKeepEditing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep Editing"
+          }
+        }
+      }
+    },
+    "widgetEditingUnsavedChangesAlertMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have unsaved alterations.  If you want to save them press ”Keep editing” > Next > Save"
+          }
+        }
+      }
+    },
+    "widgetEditingUnsavedChangesAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have unsaved changes"
           }
         }
       }

--- a/Modulite/Localization/String+LocalizedKey.swift
+++ b/Modulite/Localization/String+LocalizedKey.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+// swiftlint:disable:next blanket_disable_command
+// swiftlint:disable identifier_name
+
 extension String {
     
     /// Represents keys for localized strings in the app, allowing for dynamic localization with associated values.
@@ -89,6 +92,7 @@ extension String {
         case save
         case cancel
         case delete
+        case back
         
         // MARK: Tab Bar Titles
         case homeViewControllerTabBarItemTitle
@@ -130,6 +134,12 @@ extension String {
         case widgetEditorViewDeleteAlertTitle
         case widgetEditorViewDeleteAlertMessage
         
+        case widgetEditingUnsavedChangesAlertTitle
+        case widgetEditingUnsavedChangesAlertMessage
+        case widgetCreatingUnsavedChangesAlertMessage
+        case widgetEditingUnsavedChangesAlertActionDiscard
+        case widgetEditingUnsavedChangesAlertActionKeepEditing
+        
         // MARK: - UsageView & UsageViewController
         case usageViewYouHaveSpent
         case usageViewOnPhone
@@ -139,7 +149,7 @@ extension String {
         case usageDailyAvarageLastWeek
         case usageHowSpentYourTime
         
-        // MARK: - BloackAppsView & BlockAppsViewController
+        // MARK: - BlockAppsView & BlockAppsViewController
         case blockAppsViewBlockingSession(number: Int)
         
         // MARK: - Widget Styles

--- a/Modulite/Routers/ModalNavigationRouter.swift
+++ b/Modulite/Routers/ModalNavigationRouter.swift
@@ -44,6 +44,8 @@ extension ModalNavigationRouter: Router {
         parentViewController.dismiss(animated: animated)
     }
     
+    func dismissTopViewController(animated: Bool) { }
+    
     private func addRightSaveButton(to viewController: UIViewController) {
         viewController.navigationItem.rightBarButtonItem = UIBarButtonItem(
             title: .localized(for: .save),

--- a/Modulite/Routers/NavigationRouter.swift
+++ b/Modulite/Routers/NavigationRouter.swift
@@ -65,6 +65,12 @@ extension NavigationRouter: Router {
     }
 }
 
+extension NavigationRouter {
+    func dismissTopViewController(animated: Bool) {
+        navigationController.popViewController(animated: animated)
+    }
+}
+
 extension NavigationRouter: UINavigationControllerDelegate {
     /// Monitors navigation transitions and performs any necessary cleanup for view controllers that are removed from the stack.
     /// - Parameters:

--- a/Modulite/Routers/Router.swift
+++ b/Modulite/Routers/Router.swift
@@ -25,6 +25,8 @@ protocol Router: AnyObject {
     /// Dismisses the currently presented view controller with an optional animation.
     /// - Parameter animated: Determines if the dismissal should be animated.
     func dismiss(animated: Bool)
+    
+    func dismissTopViewController(animated: Bool)
 }
 
 /// Extension to provide default implementation for simpler presentation calls.

--- a/Modulite/Routers/SceneDelegateRouter.swift
+++ b/Modulite/Routers/SceneDelegateRouter.swift
@@ -31,4 +31,6 @@ class SceneDelegateRouter: Router {
     /// No-op implementation of dismiss, as dismissing the root view controller is not applicable.
     /// - Parameter animated: Ignored as there is no dismissal action.
     func dismiss(animated: Bool) { }
+    
+    func dismissTopViewController(animated: Bool) { }
 }

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDataSource.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDataSource.swift
@@ -1,0 +1,82 @@
+//
+//  WidgetEditorViewController+UICollectionViewDataSource.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 01/10/24.
+//
+
+import UIKit
+
+extension WidgetEditorViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        switch collectionView {
+        case editorView.widgetLayoutCollectionView: return viewModel.getCurrentModules().count
+        case editorView.moduleStyleCollectionView: return viewModel.getAvailableStyles().count
+        case editorView.moduleColorCollectionView: return viewModel.getAvailableColors().count
+        default: return 0
+        }
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        
+        switch collectionView {
+        case editorView.widgetLayoutCollectionView:
+            // MARK: - Create cells for widget
+            return handleLayoutCellCreation(for: collectionView, indexPath: indexPath)
+
+        case editorView.moduleStyleCollectionView:
+            // MARK: - Create cells for module styles
+            guard let style = viewModel.getAvailableStyle(at: indexPath.row),
+                  let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: ModuleStyleCell.reuseId,
+                    for: indexPath
+                  ) as? ModuleStyleCell else {
+                fatalError("Could not dequeue ModuleStyleCell.")
+            }
+            
+            cell.setup(with: style)
+            return cell
+            
+        case editorView.moduleColorCollectionView:
+            // MARK: - Create cells for colors
+            guard let color = viewModel.getAvailableColor(at: indexPath.row),
+                  let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: ModuleColorCell.reuseId,
+                    for: indexPath
+                  ) as? ModuleColorCell else {
+                fatalError("Could not dequeue ModuleColorCell.")
+            }
+            
+            cell.setup(with: color)
+            return cell
+            
+        default:
+            fatalError("Unsupported `UICollectionView`.")
+        }
+    }
+    
+    private func handleLayoutCellCreation(
+        for collectionView: UICollectionView,
+        indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let module = viewModel.getModule(at: indexPath.row),
+              let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: WidgetModuleCell.reuseId,
+            for: indexPath
+        ) as? WidgetModuleCell else {
+            fatalError("Could not dequeue WidgetModuleCell.")
+        }
+        
+        if let index = viewModel.selectedCellIndex {
+            cell.setEditable(index == indexPath.row)
+        } else {
+            cell.startWiggling()
+        }
+        
+        cell.setup(with: module)
+        return cell
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDelegate.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDelegate.swift
@@ -1,0 +1,133 @@
+//
+//  WidgetEditorViewController+UICollectionViewDelegate.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 01/10/24.
+//
+
+import UIKit
+
+extension WidgetEditorViewController: UICollectionViewDelegate {
+    
+    // MARK: - Change internal collectionView's position based on scroll %
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let totalScrollWidth = scrollView.contentSize.width - scrollView.bounds.width
+        let currentScrollPosition = scrollView.contentOffset.x
+        let scrollPercentage = currentScrollPosition / totalScrollWidth
+        
+        if scrollView === editorView.moduleStyleCollectionView {
+            editorView.updateCollectionViewConstraints(
+                editorView.moduleStyleCollectionView,
+                percentage: scrollPercentage
+            )
+        }
+        
+        if scrollView === editorView.moduleColorCollectionView {
+            editorView.updateCollectionViewConstraints(
+                editorView.moduleColorCollectionView,
+                percentage: scrollPercentage
+            )
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch collectionView {
+        case editorView.widgetLayoutCollectionView:
+            // MARK: - Handle widget cell touch
+            if viewModel.selectedCellIndex == indexPath.row {
+                clearSelectedModuleCell()
+                return
+            }
+            
+            selectModuleCell(at: indexPath.row)
+            
+        case editorView.moduleStyleCollectionView:
+            // MARK: - Handle module style touch
+            
+            guard let style = viewModel.getAvailableStyle(at: indexPath.row) else {
+                print("No styles found at \(indexPath.row)")
+                return
+            }
+            
+            selectStyleCell(style: style)
+            viewModel.applyStyleToSelectedModule(style)
+            editorView.widgetLayoutCollectionView.reloadData()
+            
+        case editorView.moduleColorCollectionView:
+            // MARK: - Handle module color touch
+            
+            guard let color = viewModel.getAvailableColor(at: indexPath.row) else {
+                print("No colors found at \(indexPath.row)")
+                return
+            }
+            
+            selectColorCell(color: color)
+            viewModel.applyColorToSelectedModule(color)
+            editorView.widgetLayoutCollectionView.reloadData()
+            
+        default: return
+            
+        }
+    }
+    
+    private func clearSelectedStyleCell() {
+        editorView.moduleStyleCollectionView.visibleCells.forEach { cell in
+            guard let cell = cell as? ModuleStyleCell else { return }
+            cell.setSelected(to: false)
+        }
+    }
+    
+    private func selectStyleCell(style: ModuleStyle) {
+        editorView.moduleStyleCollectionView.visibleCells.forEach { cell in
+            guard let cell = cell as? ModuleStyleCell else { return }
+            cell.setSelected(to: cell.style?.id == style.id)
+        }
+    }
+    
+    private func clearSelectedColorCell() {
+        editorView.moduleColorCollectionView.visibleCells.forEach { cell in
+            guard let cell = cell as? ModuleColorCell else { return }
+            cell.setSelected(to: false)
+        }
+    }
+    
+    private func selectColorCell(color: UIColor) {
+        editorView.moduleColorCollectionView.visibleCells.forEach { cell in
+            guard let cell = cell as? ModuleColorCell else { return }
+            cell.setSelected(to: cell.color == color)
+        }
+    }
+    
+    func clearSelectedModuleCell() {
+        viewModel.clearEditingCell()
+        editorView.disableStylingCollectionViews()
+        editorView.widgetLayoutCollectionView.subviews.forEach { cell in
+            guard let cell = cell as? WidgetModuleCell else { return }
+            cell.setEditable(true)
+        }
+        clearSelectedStyleCell()
+        clearSelectedColorCell()
+    }
+    
+    private func selectModuleCell(at index: Int) {
+        viewModel.setEditingCell(at: index)
+        editorView.enableStylingCollectionViews(
+            didSelectEmptyCell: viewModel.isModuleEmpty(at: index)
+        )
+        
+        // FIXME: - use `cellForItemAt`
+        editorView.widgetLayoutCollectionView.subviews.forEach { [weak self] cell in
+            guard let cell = cell as? WidgetModuleCell else { return }
+            
+            let row = self?.editorView.widgetLayoutCollectionView.indexPath(for: cell)?.row
+            cell.setEditable(self?.viewModel.selectedCellIndex == row)
+        }
+        
+        guard let selectedStyle = viewModel.getStyleFromSelectedModule(),
+              let selectedColor = viewModel.getColorFromSelectedModule()
+        else { return }
+        
+        selectStyleCell(style: selectedStyle)
+        selectColorCell(color: selectedColor)
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift
@@ -1,0 +1,72 @@
+//
+//  WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 01/10/24.
+//
+
+import UIKit
+
+// MARK: - UICollectionViewDragDelegate
+extension WidgetEditorViewController: UICollectionViewDragDelegate {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        itemsForBeginning session: any UIDragSession,
+        at indexPath: IndexPath
+    ) -> [UIDragItem] {
+        guard let item = viewModel.getModule(at: indexPath.row),
+              let image = item.resultingImage
+        else { return [] }
+        
+        let itemProvider = NSItemProvider(object: image as UIImage)
+        let dragItem = UIDragItem(itemProvider: itemProvider)
+        dragItem.localObject = item
+        
+        return [dragItem]
+    }
+}
+
+// MARK: - UICollectionViewDropDelegate
+extension WidgetEditorViewController: UICollectionViewDropDelegate {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        canHandle session: any UIDropSession
+    ) -> Bool {
+        return session.canLoadObjects(ofClass: UIImage.self)
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        dropSessionDidUpdate session: any UIDropSession,
+        withDestinationIndexPath destinationIndexPath: IndexPath?
+    ) -> UICollectionViewDropProposal {
+        return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        performDropWith coordinator: any UICollectionViewDropCoordinator
+    ) {
+        guard let destinationIndexPath = coordinator.destinationIndexPath else { return }
+        
+        switch coordinator.proposal.operation {
+        case .move:
+            let items = coordinator.items
+            if items.count == 1, let item = items.first, let sourceIndexPath = item.sourceIndexPath {
+                collectionView.performBatchUpdates { [weak self] in
+                    guard let viewModel = self?.viewModel
+                    else { return }
+                    
+                    viewModel.moveItem(from: sourceIndexPath.item, to: destinationIndexPath.item)
+                    
+                    collectionView.deleteItems(at: [sourceIndexPath])
+                    collectionView.insertItems(at: [destinationIndexPath])
+                }
+                
+                coordinator.drop(items.first!.dragItem, toItemAt: destinationIndexPath)
+            }
+        default:
+            return
+        }
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
@@ -17,15 +17,21 @@ protocol WidgetEditorViewControllerDelegate: AnyObject {
         _ viewController: WidgetEditorViewController,
         didDeleteWithId id: UUID
     )
+    
+    func widgetEditorViewControllerDidPressBack(
+        _ viewController: WidgetEditorViewController
+    )
 }
 
 class WidgetEditorViewController: UIViewController {
     
     // MARK: - Properties
-    private let editorView = WidgetEditorView()
-    private var viewModel: WidgetEditorViewModel!
+    private(set) var editorView = WidgetEditorView()
+    private(set) var viewModel: WidgetEditorViewModel!
     
     weak var delegate: WidgetEditorViewControllerDelegate?
+    
+    private var isCreatingNewWidget: Bool = true
     
     // MARK: - Lifecycle
     override func loadView() {
@@ -41,9 +47,35 @@ class WidgetEditorViewController: UIViewController {
         }
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        setupNavigationBar()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupNavigationBar() {
+        guard isCreatingNewWidget else { return }
+        
+        navigationItem.hidesBackButton = true
+        let backButton = UIBarButtonItem(
+            title: .localized(for: .back),
+            style: .plain,
+            target: self,
+            action: #selector(handleBackButtonPress)
+        )
+        navigationItem.leftBarButtonItem = backButton
+    }
+    
     // MARK: - Actions
+    @objc private func handleBackButtonPress() {
+        delegate?.widgetEditorViewControllerDidPressBack(self)
+    }
+    
     func setIsEditingViewToTrue() {
         editorView.setEditingMode(to: true)
+        isCreatingNewWidget = false
     }
     
     private func handleDownloadWallpaperTouch() {
@@ -130,269 +162,5 @@ extension WidgetEditorViewController {
     
     func loadDataFromBuilder(_ builder: WidgetConfigurationBuilder) {
         viewModel = WidgetEditorViewModel(widgetBuider: builder)
-    }
-}
-
-// MARK: - UICollectionViewDataSource
-extension WidgetEditorViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        switch collectionView {
-        case editorView.widgetLayoutCollectionView: return viewModel.getCurrentModules().count
-        case editorView.moduleStyleCollectionView: return viewModel.getAvailableStyles().count
-        case editorView.moduleColorCollectionView: return viewModel.getAvailableColors().count
-        default: return 0
-        }
-    }
-    
-    func collectionView(
-        _ collectionView: UICollectionView,
-        cellForItemAt indexPath: IndexPath
-    ) -> UICollectionViewCell {
-        
-        switch collectionView {
-        case editorView.widgetLayoutCollectionView:
-            // MARK: - Create cells for widget
-            return handleLayoutCellCreation(for: collectionView, indexPath: indexPath)
-
-        case editorView.moduleStyleCollectionView:
-            // MARK: - Create cells for module styles
-            guard let style = viewModel.getAvailableStyle(at: indexPath.row),
-                  let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: ModuleStyleCell.reuseId,
-                    for: indexPath
-                  ) as? ModuleStyleCell else {
-                fatalError("Could not dequeue ModuleStyleCell.")
-            }
-            
-            cell.setup(with: style)
-            return cell
-            
-        case editorView.moduleColorCollectionView:
-            // MARK: - Create cells for colors
-            guard let color = viewModel.getAvailableColor(at: indexPath.row),
-                  let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: ModuleColorCell.reuseId,
-                    for: indexPath
-                  ) as? ModuleColorCell else {
-                fatalError("Could not dequeue ModuleColorCell.")
-            }
-            
-            cell.setup(with: color)
-            return cell
-            
-        default:
-            fatalError("Unsupported `UICollectionView`.")
-        }
-    }
-    
-    private func handleLayoutCellCreation(
-        for collectionView: UICollectionView,
-        indexPath: IndexPath
-    ) -> UICollectionViewCell {
-        guard let module = viewModel.getModule(at: indexPath.row),
-              let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: WidgetModuleCell.reuseId,
-            for: indexPath
-        ) as? WidgetModuleCell else {
-            fatalError("Could not dequeue WidgetModuleCell.")
-        }
-        
-        if let index = viewModel.selectedCellIndex {
-            cell.setEditable(index == indexPath.row)
-        } else {
-            cell.startWiggling()
-        }
-        
-        cell.setup(with: module)
-        return cell
-    }
-}
-
-// MARK: - UICollectionViewDelegate
-extension WidgetEditorViewController: UICollectionViewDelegate {
-    
-    // MARK: - Change internal collectionView's position based on scroll %
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let totalScrollWidth = scrollView.contentSize.width - scrollView.bounds.width
-        let currentScrollPosition = scrollView.contentOffset.x
-        let scrollPercentage = currentScrollPosition / totalScrollWidth
-        
-        if scrollView === editorView.moduleStyleCollectionView {
-            editorView.updateCollectionViewConstraints(
-                editorView.moduleStyleCollectionView,
-                percentage: scrollPercentage
-            )
-        }
-        
-        if scrollView === editorView.moduleColorCollectionView {
-            editorView.updateCollectionViewConstraints(
-                editorView.moduleColorCollectionView,
-                percentage: scrollPercentage
-            )
-        }
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        switch collectionView {
-        case editorView.widgetLayoutCollectionView:
-            // MARK: - Handle widget cell touch
-            if viewModel.selectedCellIndex == indexPath.row {
-                clearSelectedModuleCell()
-                return
-            }
-            
-            selectModuleCell(at: indexPath.row)
-            
-        case editorView.moduleStyleCollectionView:
-            // MARK: - Handle module style touch
-            
-            guard let style = viewModel.getAvailableStyle(at: indexPath.row) else {
-                print("No styles found at \(indexPath.row)")
-                return
-            }
-            
-            selectStyleCell(style: style)
-            viewModel.applyStyleToSelectedModule(style)
-            editorView.widgetLayoutCollectionView.reloadData()
-            
-        case editorView.moduleColorCollectionView:
-            // MARK: - Handle module color touch
-            
-            guard let color = viewModel.getAvailableColor(at: indexPath.row) else {
-                print("No colors found at \(indexPath.row)")
-                return
-            }
-            
-            selectColorCell(color: color)
-            viewModel.applyColorToSelectedModule(color)
-            editorView.widgetLayoutCollectionView.reloadData()
-            
-        default: return
-        }
-    }
-    
-    private func clearSelectedStyleCell() {
-        editorView.moduleStyleCollectionView.visibleCells.forEach { cell in
-            guard let cell = cell as? ModuleStyleCell else { return }
-            cell.setSelected(to: false)
-        }
-    }
-    
-    private func selectStyleCell(style: ModuleStyle) {
-        editorView.moduleStyleCollectionView.visibleCells.forEach { cell in
-            guard let cell = cell as? ModuleStyleCell else { return }
-            cell.setSelected(to: cell.style?.id == style.id)
-        }
-    }
-    
-    private func clearSelectedColorCell() {
-        editorView.moduleColorCollectionView.visibleCells.forEach { cell in
-            guard let cell = cell as? ModuleColorCell else { return }
-            cell.setSelected(to: false)
-        }
-    }
-    
-    private func selectColorCell(color: UIColor) {
-        editorView.moduleColorCollectionView.visibleCells.forEach { cell in
-            guard let cell = cell as? ModuleColorCell else { return }
-            cell.setSelected(to: cell.color == color)
-        }
-    }
-    
-    private func clearSelectedModuleCell() {
-        viewModel.clearEditingCell()
-        editorView.disableStylingCollectionViews()
-        editorView.widgetLayoutCollectionView.subviews.forEach { cell in
-            guard let cell = cell as? WidgetModuleCell else { return }
-            cell.setEditable(true)
-        }
-        clearSelectedStyleCell()
-        clearSelectedColorCell()
-    }
-    
-    private func selectModuleCell(at index: Int) {
-        viewModel.setEditingCell(at: index)
-        editorView.enableStylingCollectionViews(
-            didSelectEmptyCell: viewModel.isModuleEmpty(at: index)
-        )
-        
-        // FIXME: - use `cellForItemAt`
-        editorView.widgetLayoutCollectionView.subviews.forEach { [weak self] cell in
-            guard let cell = cell as? WidgetModuleCell else { return }
-            
-            let row = self?.editorView.widgetLayoutCollectionView.indexPath(for: cell)?.row
-            cell.setEditable(self?.viewModel.selectedCellIndex == row)
-        }
-        
-        guard let selectedStyle = viewModel.getStyleFromSelectedModule(),
-              let selectedColor = viewModel.getColorFromSelectedModule()
-        else { return }
-        
-        selectStyleCell(style: selectedStyle)
-        selectColorCell(color: selectedColor)
-    }
-}
-
-// MARK: - UICollectionViewDragDelegate
-extension WidgetEditorViewController: UICollectionViewDragDelegate {
-    func collectionView(
-        _ collectionView: UICollectionView,
-        itemsForBeginning session: any UIDragSession,
-        at indexPath: IndexPath
-    ) -> [UIDragItem] {
-        guard let item = viewModel.getModule(at: indexPath.row),
-              let image = item.resultingImage
-        else { return [] }
-        
-        let itemProvider = NSItemProvider(object: image as UIImage)
-        let dragItem = UIDragItem(itemProvider: itemProvider)
-        dragItem.localObject = item
-        
-        return [dragItem]
-    }
-}
-
-// MARK: - UICollectionViewDropDelegate
-extension WidgetEditorViewController: UICollectionViewDropDelegate {
-    func collectionView(
-        _ collectionView: UICollectionView,
-        canHandle session: any UIDropSession
-    ) -> Bool {
-        return session.canLoadObjects(ofClass: UIImage.self)
-    }
-    
-    func collectionView(
-        _ collectionView: UICollectionView,
-        dropSessionDidUpdate session: any UIDropSession,
-        withDestinationIndexPath destinationIndexPath: IndexPath?
-    ) -> UICollectionViewDropProposal {
-        return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
-    }
-    
-    func collectionView(
-        _ collectionView: UICollectionView,
-        performDropWith coordinator: any UICollectionViewDropCoordinator
-    ) {
-        guard let destinationIndexPath = coordinator.destinationIndexPath else { return }
-        
-        switch coordinator.proposal.operation {
-        case .move:
-            let items = coordinator.items
-            if items.count == 1, let item = items.first, let sourceIndexPath = item.sourceIndexPath {
-                collectionView.performBatchUpdates { [weak self] in
-                    guard let viewModel = self?.viewModel
-                    else { return }
-                    
-                    viewModel.moveItem(from: sourceIndexPath.item, to: destinationIndexPath.item)
-                    
-                    collectionView.deleteItems(at: [sourceIndexPath])
-                    collectionView.insertItems(at: [destinationIndexPath])
-                }
-                
-                coordinator.drop(items.first!.dragItem, toItemAt: destinationIndexPath)
-            }
-        default:
-            return
-        }
     }
 }

--- a/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
@@ -12,15 +12,8 @@ class WidgetSetupView: UIScrollView {
     
     // MARK: - Properties
     
-    private var isEditing: Bool = false {
-        didSet {
-            saveWidgetButton.isHidden = !isEditing
-        }
-    }
-    
     var onSearchButtonPressed: (() -> Void)?
     var onNextButtonPressed: (() -> Void)?
-    var onSaveButtonPressed: (() -> Void)?
     
     var isStyleSelected = false
     var hasAppsSelected = false
@@ -136,40 +129,6 @@ class WidgetSetupView: UIScrollView {
         return view
     }()
     
-    private(set) lazy var saveWidgetButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = .fiestaGreen
-        config.title = .localized(for: .save).uppercased()
-        config.imagePlacement = .leading
-        config.image = UIImage(systemName: "envelope")
-        config.imagePadding = 10
-        config.preferredSymbolConfigurationForImage = .init(pointSize: 20, weight: .bold)
-        config.baseForegroundColor = .white
-        
-        let view = UIButton(configuration: config)
-        
-        view.isHidden = true
-        
-        view.addTarget(self, action: #selector(handleSaveButtonPressed), for: .touchUpInside)
-        view.configurationUpdateHandler = { [weak self] btn in
-            guard let self = self, var config = btn.configuration else { return }
-            
-            btn.isEnabled = self.isStyleSelected && self.hasAppsSelected
-            
-            switch btn.state {
-            case .disabled:
-                config.background.backgroundColor = .systemGray2
-                
-            default:
-                config.background.backgroundColor = .fiestaGreen
-            }
-            
-            btn.configuration = config
-        }
-        
-        return view
-    }()
-    
     // MARK: - Actions
     func getWidgetName() -> String {
         guard let name = widgetNameTextField.text, !name.isEmpty else {
@@ -195,10 +154,6 @@ class WidgetSetupView: UIScrollView {
         onNextButtonPressed?()
     }
     
-    @objc private func handleSaveButtonPressed() {
-        onSaveButtonPressed?()
-    }
-    
     // MARK: - Initializers
     
     override init(frame: CGRect) {
@@ -217,11 +172,7 @@ class WidgetSetupView: UIScrollView {
     }
     
     // MARK: - Setup methods
-    
-    func setEditingMode(to value: Bool) {
-        isEditing = value
-    }
-    
+        
     func updateSelectedAppsCollectionViewHeight() {
         selectedAppsCollectionView.snp.updateConstraints { make in
             make.height.greaterThanOrEqualTo(selectedAppsCollectionView.contentSize.height)
@@ -286,8 +237,6 @@ class WidgetSetupView: UIScrollView {
         contentView.addSubview(selectedAppsCollectionView)
         contentView.addSubview(searchAppsHelperText)
         contentView.addSubview(nextViewButton)
-                
-        contentView.addSubview(saveWidgetButton)
     }
     
     private func setupConstraints() {
@@ -339,11 +288,6 @@ class WidgetSetupView: UIScrollView {
             make.width.equalTo(160)
             make.height.equalTo(45)
             make.bottom.equalToSuperview()
-        }
-                
-        saveWidgetButton.snp.makeConstraints { make in
-            make.height.bottom.width.equalTo(nextViewButton)
-            make.right.equalTo(nextViewButton.snp.left).offset(-32)
         }
     }
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #88, implementing alert dialogs when attempting to leave the widget editing screen without saving changes.

## Summary

The following changes have been made to enhance the user experience when editing widgets:

1. **Leave Editing Alert**: Added logic to display an alert when the user tries to leave the widget editing view without saving. This ensures that users are aware they have unsaved changes and provides the option to either cancel the action or discard changes and proceed with leaving.
   
2. **Customized Back Button**: Implemented a customized back button in the `WidgetEditorViewController` to ensure the alert is triggered when users navigate back using the navigation bar.

3. **Dismissal and Alert Handling via Router**: Refactored the routing logic to include methods for presenting alerts and dismissing views when necessary. This keeps the navigation and alert handling centralized and consistent across the app.

4. **File Organization**: Refactored the `WidgetEditorViewController` into multiple files to reduce file size and improve maintainability, separating concerns and making the codebase more modular.

## Testing

- Verified that the alert is displayed when attempting to leave the widget editing screen with unsaved changes.
- Confirmed that the user can either discard changes and leave, or cancel the action to remain in the editor.
- Tested the customized back button to ensure that it triggers the alert as expected.
- Ensured consistent behavior when dismissing the top view controller and when presenting alerts from different parts of the app.