### PR TITLE
Reset All Cell States Upon Drag or Drop

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Editor/View/CollectionViewCells/WidgetModuleCell.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/CollectionViewCells/WidgetModuleCell.swift
@@ -77,7 +77,7 @@ class WidgetModuleCell: UICollectionViewCell {
     func setEditable(_ value: Bool) {
         if !value && self.moduleImageView.alpha == 0.5 { return }
         
-        UIView.animate(withDuration: 0.25) { [weak self] in
+        UIView.animate(withDuration: 0.1) { [weak self] in
             self?.moduleImageView.alpha = value ?  1 : 0.5
             self?.appNameLabel.alpha = value ?  1 : 0.5
         }

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDragAndDropDelegate.swift
@@ -21,7 +21,7 @@ extension WidgetEditorViewController: UICollectionViewDragDelegate {
         let itemProvider = NSItemProvider(object: image as UIImage)
         let dragItem = UIDragItem(itemProvider: itemProvider)
         dragItem.localObject = item
-        
+        clearSelectedModuleCell()
         return [dragItem]
     }
 }
@@ -64,6 +64,7 @@ extension WidgetEditorViewController: UICollectionViewDropDelegate {
                 }
                 
                 coordinator.drop(items.first!.dragItem, toItemAt: destinationIndexPath)
+                clearSelectedModuleCell()
             }
         default:
             return


### PR DESCRIPTION
## Issue Reference

This PR closes #57, implementing logic that ensures dragging a cell deselects all other cells, effectively resetting their state.

## Summary

The following changes have been made to improve the user interaction when rearranging cells:

1. **Deselecting Cells on Drag**: Implemented functionality that deselects any previously selected cells when a cell is dragged. This ensures that the UI reflects a consistent state by resetting the selection of all other cells during the drag action.
   
2. **Resetting Cell States**: When the user drags a cell, the state of all cells is reset to ensure no cell remains in a selected state. This avoids confusion or unexpected behavior where multiple cells might appear selected, ensuring a clear interaction flow.

## Testing

- Verified that dragging any cell correctly resets the selection state of all other cells.
- Ensured that no cells remain selected after the drag operation, and the UI updates accordingly.
- Tested different scenarios with multiple cells to confirm consistent behavior across various cell configurations.