### PR TITLE
Fix Widget Image Saving Bug

### DIFF
--- a/Modulite/Builders/WidgetConfigurationBuilder.swift
+++ b/Modulite/Builders/WidgetConfigurationBuilder.swift
@@ -117,18 +117,17 @@ class WidgetConfigurationBuilder {
         guard sourceIndex != destinationIndex,
               sourceIndex >= 0, sourceIndex < configuration.modules.count,
               destinationIndex >= 0, destinationIndex < configuration.modules.count else {
-            print("Invalid indices")
+            print("Invalid indexes when moving items.")
             return
         }
         
         let movingItem = configuration.modules[sourceIndex]
-        let replacedItem = configuration.modules[destinationIndex]
-                
-        replacedItem.index = sourceIndex
-        movingItem.index = destinationIndex
-        
         configuration.modules.remove(at: sourceIndex)
         configuration.modules.insert(movingItem, at: destinationIndex)
+        
+        for (index, module) in configuration.modules.enumerated() {
+            module.index = index
+        }
     }
     
     // MARK: - Build

--- a/Modulite/Singleton/WidgetImagePersistence/FileManagerImagePersistenceController.swift
+++ b/Modulite/Singleton/WidgetImagePersistence/FileManagerImagePersistenceController.swift
@@ -35,12 +35,12 @@ class FileManagerImagePersistenceController {
         
         let completeUrl = url.appending(component: "widget.png")
         
-        if let imageData = try? Data(contentsOf: completeUrl) {
-            return UIImage(data: imageData)
-        } else {
+        guard let imageData = try? Data(contentsOf: completeUrl) else {
             print("Unable to load image data from \(completeUrl)")
             return nil
         }
+        
+        return UIImage(data: imageData)
     }
     
     func getModuleImages(for widgetId: UUID) -> [UIImage] {
@@ -56,23 +56,19 @@ class FileManagerImagePersistenceController {
                         
             let indexFileMap: [(Int, String)] = pngFiles.compactMap { fileName in
                 let indexString = fileName.replacingOccurrences(of: ".png", with: "")
-                if let index = Int(indexString) {
-                    return (index, fileName)
-                } else {
-                    return nil
-                }
+                guard let index = Int(indexString) else { return nil }
+                
+                return (index, fileName)
             }
                         
             let sortedIndexFileMap = indexFileMap.sorted { $0.0 < $1.0 }
                         
             for (_, fileName) in sortedIndexFileMap {
                 let fileURL = modulesDirectory.appendingPathComponent(fileName)
-                if let imageData = try? Data(contentsOf: fileURL),
-                   let image = UIImage(data: imageData) {
-                    images.append(image)
-                } else {
-                    print("Unable to load image at \(fileURL)")
-                }
+                guard let imageData = try? Data(contentsOf: fileURL),
+                      let image = UIImage(data: imageData) else { continue }
+                
+                images.append(image)
             }
         } catch {
             print("Error accessing modules directory: \(error)")
@@ -124,6 +120,7 @@ extension FileManagerImagePersistenceController {
                     attributes: nil
                 )
             }
+            
             if !FileManager.default.fileExists(atPath: modulesDirectory.path) {
                 try FileManager.default.createDirectory(
                     at: modulesDirectory,
@@ -131,6 +128,7 @@ extension FileManagerImagePersistenceController {
                     attributes: nil
                 )
             }
+            
         } catch {
             fatalError("Failed to create directories: \(error.localizedDescription)")
         }
@@ -151,7 +149,9 @@ extension FileManagerImagePersistenceController {
         
         do {
             try imageData?.write(to: imageURL)
+            
             return imageURL
+            
         } catch {
             fatalError("Failed to save image: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Issue Reference

This PR closes #109, fixing a bug where widgets were not being saved correctly due to inconsistencies in module indexing when rearranging modules in the widget editor.

## Summary

The issue occurred because, when moving a module within the widget editor, only the starting and ending indices of the modules were being updated. This caused inconsistencies between the real order of the modules and their stored indices, resulting in widgets not being saved correctly.

### Fix:
- **Updated All Module Indices on Move**: The fix ensures that all module indices are updated after a module is moved. Instead of only updating the start and end points, every module in the configuration now has its index updated to match its actual position in the list. This guarantees that the stored indices are always consistent with the real order of the modules, preventing any inconsistencies during the save process.

## Testing

- Verified that moving a module within the widget editor correctly updates the indices of all modules.
- Ensured that no inconsistencies occur between the real order of the modules and their stored indices.
- Tested various scenarios with multiple modules and confirmed that widgets are now saved correctly, with no data loss or index mismatches.

## Next Steps

- Continue monitoring widget editing and saving workflows for any edge cases that might cause further issues.