### PR TITLE
Fixed Back Button Navigation

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
@@ -47,25 +47,20 @@ class WidgetEditorViewController: UIViewController {
         }
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidLoad() {
+        super.viewDidLoad()
         
         setupNavigationBar()
     }
     
     // MARK: - Setup
     
-    private func setupNavigationBar() {
+    func setupNavigationBar() {
         guard isCreatingNewWidget else { return }
         
-        navigationItem.hidesBackButton = true
-        let backButton = UIBarButtonItem(
-            title: .localized(for: .back),
-            style: .plain,
-            target: self,
-            action: #selector(handleBackButtonPress)
-        )
-        navigationItem.leftBarButtonItem = backButton
+        navigationItem.backAction = UIAction { [weak self] _ in
+            self?.handleBackButtonPress()
+        }
     }
     
     // MARK: - Actions

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
@@ -53,6 +53,7 @@ class WidgetSetupViewController: UIViewController {
         super.viewDidLoad()
         
         configureViewDependencies()
+        setupNavigationBar()
     }
     
     override func viewWillLayoutSubviews() {
@@ -60,23 +61,13 @@ class WidgetSetupViewController: UIViewController {
         setupView.updateSelectedAppsCollectionViewHeight()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        setupNavigationBar()
-    }
-    
     // MARK: - Setup methods
     func setupNavigationBar() {
         guard isEditingWidget else { return }
         
-        navigationItem.hidesBackButton = true
-        let backButton = UIBarButtonItem(
-            title: .localized(for: .back),
-            style: .plain,
-            target: self,
-            action: #selector(handleBackButtonPress)
-        )
-        navigationItem.leftBarButtonItem = backButton
+        navigationItem.backAction = UIAction { [weak self] _ in
+            self?.handleBackButtonPress()
+        }
     }
     
     func setToWidgetEditingMode() {


### PR DESCRIPTION
## Issue Reference

This PR closes #110, fixing an issue where a custom back button was preventing the swipe gesture for navigation. The issue has been resolved by removing the custom button and handling the back action through `navigationItem.backAction`.

## Summary

The following changes have been made to resolve the issue and maintain proper navigation behavior:

1. **Removed Custom Back Button**: The custom back button, which was blocking the swipe-to-go-back gesture, has been removed. This restores the native swipe gesture functionality for navigating back.

2. **Custom Back Action with `navigationItem.backAction`**: Instead of using a custom button, a custom action is now assigned to `navigationItem.backAction`, ensuring the correct behavior when the user taps the back button while keeping the swipe gesture functional.

### Known Limitation:
- **Swipe Gesture Does Not Trigger Alert**: While this resolves the issue with swipe navigation, the current implementation does **not trigger the unsaved changes alert** when the user swipes to go back. This could lead to cases where users unintentionally lose unsaved changes. Further adjustments might be necessary to ensure the alert is shown for both swipe and back button actions.

## Testing

- Verified that the swipe gesture now works as expected for navigating back.
- Confirmed that the custom back action triggers the alert when the user taps the back button.
- Tested the navigation behavior to ensure that no regressions were introduced with the removal of the custom button.