### PR TITLE
Fix Widget Style Change in Editing

### DIFF
--- a/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
+++ b/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator.swift
@@ -146,6 +146,10 @@ extension WidgetBuilderCoordinator: WidgetSetupViewControllerDelegate {
         style: WidgetStyle
     ) {
         contentBuilder.setWidgetStyle(style)
+        
+        if let config = injectedConfiguration {
+            config.randomizeWithNewStyle(style)
+        }
     }
     
     func widgetSetupViewControllerDidTapSearchApps(

--- a/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
+++ b/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class ModuliteWidgetConfiguration: Copying {
+    // MARK: - Properties
+    
     var id: UUID = UUID()
     var name: String?
     var widgetStyle: WidgetStyle?
@@ -26,6 +28,8 @@ class ModuliteWidgetConfiguration: Copying {
     }
     
     var createdAt: Date!
+    
+    // MARK: - Initializers
     
     init() { }
     
@@ -56,8 +60,29 @@ class ModuliteWidgetConfiguration: Copying {
             createdAt: prototype.createdAt ?? .now
         )
     }
+    
+    // MARK: - Actions
+    
+    func randomizeWithNewStyle(_ style: WidgetStyle) {
+        for i in 0..<modules.count {
+            let module = modules[i]
+            if module.isEmpty {
+                modules[i] = .empty(style: style, at: module.index)
+                continue
+            }
+            
+            modules[i] = .init(
+                index: module.index,
+                appName: module.appName,
+                associatedURLScheme: module.associatedURLScheme,
+                selectedStyle: style.getRandomStyle(),
+                selectedColor: style.defaultColor
+            )
+        }
+    }
 }
 
+// MARK: - Persistence
 extension ModuliteWidgetConfiguration {
     convenience init(persistedConfiguration config: PersistableWidgetConfiguration) {
         guard let key = WidgetStyleKey(rawValue: config.widgetStyleKey) else {


### PR DESCRIPTION
## Issue Reference

This PR closes #118, fixing an issue where changing the widget style in the editor did not visually update the widget.

## Summary

The following changes were made to ensure that updating the widget style in the editor immediately reflects the new style on the widget preview:

1. **Fixed Widget Style Update in Editor**: Resolved the issue where changing the style of a widget in the editor would not apply the new style to the widget preview. Now, whenever the user selects a different style, the widget's appearance is correctly updated in real time.

2. **Improved Feedback on Style Change**: The editor now provides immediate visual feedback when a new style is selected, enhancing the user experience by making the widget customization more intuitive and responsive.

## Testing

- Verified that selecting a new style in the widget editor correctly updates the widget preview.
- Ensured that all available widget styles apply as expected when selected.