### PR TITLE
Implemented Auxiliary Widget Create Alert

### DIFF
--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -33,9 +33,36 @@ class HomeCoordinator: Coordinator {
 }
 
 extension HomeCoordinator: HomeViewControllerDelegate {
+    private func presentFeatureComingAlert(_ parentViewController: UIViewController) {
+        let alert = UIAlertController(
+            title: .localized(for: .comingSoonTitle),
+            message: .localized(
+                for: .comingSoonMessage(
+                    feature: .localized(for: .homeViewAuxiliarySectionHeaderTitle)
+                )
+            ),
+            preferredStyle: .alert
+        )
+        
+        let okAction = UIAlertAction(
+            title: .localized(for: .okay).uppercased(),
+            style: .cancel
+        )
+        
+        alert.addAction(okAction)
+        
+        parentViewController.present(alert, animated: true)
+    }
+    
     func homeViewControllerDidStartWidgetCreationFlow(
-        _ viewController: HomeViewController
+        _ viewController: HomeViewController,
+        type: WidgetType
     ) {
+        guard type == .main else {
+            presentFeatureComingAlert(viewController)
+            return
+        }
+        
         let coordinator = WidgetBuilderCoordinator(
             router: router,
             currentWidgetCount: viewController.getCurrentMainWidgetCount()

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -76,6 +76,28 @@
     "Cancel" : {
 
     },
+    "comingSoonMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ are coming to Modu.lite soon!"
+          }
+        }
+      }
+    },
+    "comingSoonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coming soon…"
+          }
+        }
+      }
+    },
     "delete" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -239,6 +261,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "NEXT"
+          }
+        }
+      }
+    },
+    "okay" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ok"
           }
         }
       }

--- a/Modulite/Localization/String+LocalizedKey.swift
+++ b/Modulite/Localization/String+LocalizedKey.swift
@@ -133,12 +133,15 @@ extension String {
         // MARK: - Localized Keys -
         
         // MARK: - Reusable texts
+        case okay
         case next
         case save
         case cancel
         case delete
         case back
         case plus
+        case comingSoonTitle
+        case comingSoonMessage(feature: String)
         
         // MARK: - Tab Bar Titles
         case homeViewControllerTabBarItemTitle

--- a/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
+++ b/Modulite/Models/Widget/ModuliteWidgetConfiguration.swift
@@ -7,6 +7,11 @@
 
 import UIKit
 
+enum WidgetType {
+    case main
+    case auxiliary
+}
+
 class ModuliteWidgetConfiguration: Copying {
     // MARK: - Properties
     

--- a/Modulite/Screens/Home/View/CollectionViewCells/HomeHeaderReusableCell.swift
+++ b/Modulite/Screens/Home/View/CollectionViewCells/HomeHeaderReusableCell.swift
@@ -54,9 +54,9 @@ class HomeHeaderReusableCell: UICollectionViewCell {
     
     func setup(
         title: String,
-        buttonImage: UIImage,
+        buttonImage: UIImage? = nil,
         buttonColor: UIColor = .fiestaGreen,
-        buttonAction: @escaping () -> Void,
+        buttonAction: @escaping () -> Void = {},
         isPlusExclusive: Bool = false
     ) {
         actionButton.configuration?.image = buttonImage

--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 
 protocol HomeViewControllerDelegate: AnyObject {
     func homeViewControllerDidStartWidgetCreationFlow(
-        _ viewController: HomeViewController
+        _ viewController: HomeViewController,
+        type: WidgetType
     )
     
     func homeViewControllerDidStartWidgetEditingFlow(
@@ -221,7 +222,10 @@ extension HomeViewController: UICollectionViewDataSource {
                 buttonImage: UIImage(systemName: "plus.circle")!,
                 buttonAction: { [weak self] in
                     guard let self = self else { return }
-                    self.delegate?.homeViewControllerDidStartWidgetCreationFlow(self)
+                    self.delegate?.homeViewControllerDidStartWidgetCreationFlow(
+                        self,
+                        type: .main
+                    )
                 }
             )
             
@@ -231,19 +235,17 @@ extension HomeViewController: UICollectionViewDataSource {
                 buttonImage: UIImage(systemName: "plus.circle")!,
                 buttonAction: { [weak self] in
                     guard let self = self else { return }
-                    self.delegate?.homeViewControllerDidStartWidgetCreationFlow(self)
+                    self.delegate?.homeViewControllerDidStartWidgetCreationFlow(
+                        self,
+                        type: .auxiliary
+                    )
                 },
                 isPlusExclusive: true
             )
             
         case homeView.tipsCollectionView:
             header.setup(
-                title: .localized(for: .homeViewTipsSectionHeaderTitle),
-                buttonImage: UIImage(systemName: "ellipsis")!,
-                buttonColor: .systemGray,
-                buttonAction: {
-                    // TODO: Implement this
-                }
+                title: .localized(for: .homeViewTipsSectionHeaderTitle)
             )
             
         default: fatalError("Unsupported collection view.")


### PR DESCRIPTION
## Issue Reference

This PR closes #102, adding an alert to inform users that **auxiliary widgets** are currently under development and will be available soon.

## Summary

The following feature has been added to keep users informed about upcoming functionality:

1. **"Coming Soon" Alert for Auxiliary Widgets**: Implemented an alert that notifies users when they attempt to access **auxiliary widgets**, indicating that these widgets are still in development and will be **"coming soon"**. This helps manage user expectations by providing clear communication about the status of this feature.

2. **User-Friendly Messaging**: The alert message has been crafted to be informative yet friendly, encouraging users to stay tuned for upcoming updates without causing confusion or frustration.

## Testing

- Verified that the alert is displayed correctly whenever a user attempts to interact with auxiliary widgets.
- Tested the alert message for different user flows to ensure it provides consistent and clear communication.
- Ensured that the alert text is localized, making the message accessible to users in different languages.