### PR TITLE
Limit Widget Creation For Free Users

### DIFF
--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -54,12 +54,36 @@ extension HomeCoordinator: HomeViewControllerDelegate {
         parentViewController.present(alert, animated: true)
     }
     
+    func presentMaxWidgetCountAlert(_ parentViewController: UIViewController) {
+        let alert = UIAlertController(
+            title: .localized(for: .homeViewMainWidgetsDidReachMaxCountAlertTitle),
+            message: .localized(
+                for: .homeViewMainWidgetsDidReachMaxCountAlertMessage
+            ),
+            preferredStyle: .alert
+        )
+        
+        let okAction = UIAlertAction(
+            title: .localized(for: .okay).uppercased(),
+            style: .cancel
+        )
+        
+        alert.addAction(okAction)
+        
+        parentViewController.present(alert, animated: true)
+    }
+    
     func homeViewControllerDidStartWidgetCreationFlow(
         _ viewController: HomeViewController,
         type: WidgetType
     ) {
         guard type == .main else {
             presentFeatureComingAlert(viewController)
+            return
+        }
+        
+        guard viewController.getCurrentMainWidgetCount() < 3 else {
+            presentMaxWidgetCountAlert(viewController)
             return
         }
         

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -604,6 +604,28 @@
         }
       }
     },
+    "homeViewMainWidgetsDidReachMaxCountAlertMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soon you'll be able to upgrade to the premium subscription to create more widgets!"
+          }
+        }
+      }
+    },
+    "homeViewMainWidgetsDidReachMaxCountAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You've reached your widget limit"
+          }
+        }
+      }
+    },
     "homeViewMainWidgetsPlaceholderSubtitle1" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modulite/Localization/String+LocalizedKey.swift
+++ b/Modulite/Localization/String+LocalizedKey.swift
@@ -167,6 +167,9 @@ extension String {
         case homeViewMainWidgetsPlaceholderSubtitle2
         case homeViewAuxiliaryWidgetsPlaceholderTitle
         
+        case homeViewMainWidgetsDidReachMaxCountAlertTitle
+        case homeViewMainWidgetsDidReachMaxCountAlertMessage
+        
         // MARK: - WidgetSetupView & WidgetSetupViewController
         case widgetSetupViewMainWidgetNamePlaceholder(number: Int)
         case widgetSetupViewStyleHeaderTitle

--- a/Modulite/Screens/Home/View/CollectionViewCells/HomeHeaderReusableCell.swift
+++ b/Modulite/Screens/Home/View/CollectionViewCells/HomeHeaderReusableCell.swift
@@ -48,6 +48,15 @@ class HomeHeaderReusableCell: UICollectionViewCell {
         return view
     }()
     
+    private(set) var countLabel: UILabel = {
+        let view = UILabel()
+        
+        view.font = UIFont(textStyle: .body, weight: .regular)
+        view.textColor = .secondaryLabel
+        
+        return view
+    }()
+    
     private(set) lazy var plusBadge = ModulitePlusSmallBadge()
     
     // MARK: - Setup methods
@@ -57,27 +66,44 @@ class HomeHeaderReusableCell: UICollectionViewCell {
         buttonImage: UIImage? = nil,
         buttonColor: UIColor = .fiestaGreen,
         buttonAction: @escaping () -> Void = {},
-        isPlusExclusive: Bool = false
+        isPlusExclusive: Bool = false,
+        countValues: (current: Int, max: Int)? = nil
     ) {
         actionButton.configuration?.image = buttonImage
         actionButton.configuration?.baseForegroundColor = buttonColor
         onButtonTap = buttonAction
-        
-        addSubviews(isPlusExclusive)
-        setupContraints(isPlusExclusive)
-        
         titleLabel.text = title
+        
+        var shouldAddCount: Bool
+        if let (count, max) = countValues {
+            shouldAddCount = true
+            countLabel.text = "\(count)/\(max)"
+            
+        } else {
+            shouldAddCount = false
+        }
+        
+        addSubviews(shouldAddBadge: isPlusExclusive, shouldAddCount: shouldAddCount)
+        setupContraints(shouldAddBadge: isPlusExclusive, shouldAddCount: shouldAddCount)
     }
     
-    private func addSubviews(_ shouldAddBadge: Bool) {
+    private func addSubviews(
+        shouldAddBadge: Bool,
+        shouldAddCount: Bool
+    ) {
         addSubview(titleLabel)
         
         if shouldAddBadge { addSubview(plusBadge) }
         
         addSubview(actionButton)
+        
+        if shouldAddCount { addSubview(countLabel) }
     }
     
-    private func setupContraints(_ shouldAddBadge: Bool) {
+    private func setupContraints(
+        shouldAddBadge: Bool,
+        shouldAddCount: Bool
+    ) {
         titleLabel.snp.makeConstraints { make in
             make.top.left.bottom.equalToSuperview()
         }
@@ -86,17 +112,33 @@ class HomeHeaderReusableCell: UICollectionViewCell {
             make.top.right.bottom.equalToSuperview()
         }
         
-        guard shouldAddBadge else { return }
+        if shouldAddBadge {
+            plusBadge.snp.makeConstraints { make in
+                make.width.equalTo(70)
+                make.height.equalTo(31)
+                make.centerY.equalTo(titleLabel)
+                make.left.equalTo(titleLabel.snp.right).offset(12)
+            }
+        }
         
-        plusBadge.snp.makeConstraints { make in
-            make.width.equalTo(70)
-            make.height.equalTo(31)
-            make.centerY.equalTo(titleLabel)
-            make.left.equalTo(titleLabel.snp.right).offset(12)
+        if shouldAddCount {
+            countLabel.snp.makeConstraints { make in
+                make.centerY.equalTo(actionButton)
+                make.right.equalTo(actionButton.snp.left)
+            }
         }
     }
     
     // MARK: - Actions
+    
+    func updateCurrentCount(to newCount: Int) {
+        guard let text = countLabel.text else { return }
+        
+        var separated = text.components(separatedBy: "/")
+        separated[0] = String(newCount)
+        
+        countLabel.text = separated.joined(separator: "/")
+    }
     
     @objc func handleButtonTap() {
         onButtonTap?()

--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -85,6 +85,9 @@ class HomeViewController: UIViewController {
         
         homeView.mainWidgetsCollectionView.performBatchUpdates { [weak self] in
             self?.homeView.mainWidgetsCollectionView.insertItems(at: [indexPath])
+        } completion: { [weak self] _ in
+            let indexSet = IndexSet(integer: 0)
+            self?.homeView.mainWidgetsCollectionView.reloadSections(indexSet)
         }
         
         updatePlaceholderViews()
@@ -110,6 +113,10 @@ class HomeViewController: UIViewController {
         viewModel.deleteMainWidget(widget)
         homeView.mainWidgetsCollectionView.performBatchUpdates { [weak self] in
             self?.homeView.mainWidgetsCollectionView.deleteItems(at: [indexPath])
+        }
+        completion: { [weak self] _ in
+            let indexSet = IndexSet(integer: 0)
+            self?.homeView.mainWidgetsCollectionView.reloadSections(indexSet)
         }
         
         updatePlaceholderViews()
@@ -211,8 +218,11 @@ extension HomeViewController: UICollectionViewDataSource {
                         self,
                         type: .main
                     )
-                }
+                },
+                countValues: (current: viewModel.mainWidgets.count, max: 3)
             )
+            
+            header.updateCurrentCount(to: viewModel.mainWidgets.count)
             
         case homeView.auxiliaryWidgetsCollectionView:
             header.setup(

--- a/Modulite/Screens/RootTabBarController.swift
+++ b/Modulite/Screens/RootTabBarController.swift
@@ -78,6 +78,11 @@ class RootTabBarController: UITabBarController {
             clockwise: true
         )
         
+        circleLayer.shadowColor = UIColor.black.cgColor
+        circleLayer.shadowOpacity = 0.2
+        circleLayer.shadowOffset = CGSize(width: 1, height: 1)
+        circleLayer.shadowRadius = 2
+        
         let newFillColor = getColorForSelectedTag().cgColor
         
         UIView.animate(withDuration: 0.2) { [weak self] in


### PR DESCRIPTION
## Issue Reference

This PR closes #101, adding a limit on the number of widgets that can be created with the free version to **3**.

## Summary

- **Widget Limit for Free Version**: Implemented a limit of **3 widgets** for users of the free version of the app. This encourages users to upgrade to a premium plan if they want to create more widgets, while still providing a useful experience with the free version.

- **User Notification**: Added a message that informs users when they reach the maximum number of widgets allowed. The message guides them to consider upgrading if they need more widgets, ensuring the limitation is communicated clearly.

## Testing

- Verified that users are unable to create more than 3 widgets in the free version.
- Confirmed that the correct message is displayed once the limit is reached.
- Ensured that the app remains stable and provides proper feedback when users attempt to exceed the limit.