### PR TITLE
Implemented Displaying of Usage Times in `UsageActivityView`

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -258,6 +258,13 @@
 		B3CC57C52CBF393E00945DE2 /* TimeInterval+ToHoursAndMinutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC57C42CBF393E00945DE2 /* TimeInterval+ToHoursAndMinutes.swift */; };
 		B3CC57C72CBF394900945DE2 /* AsyncSequence+Collect.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC57C62CBF394900945DE2 /* AsyncSequence+Collect.swift */; };
 		B3CC57CB2CBF3C7F00945DE2 /* UsageActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC57C92CBF3C7F00945DE2 /* UsageActivityView.swift */; };
+		B3CC57CD2CBF7BD100945DE2 /* DeviceActivityReportAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B3CC57CC2CBF7BD100945DE2 /* DeviceActivityReportAssets.xcassets */; };
+		B3CC57CF2CBF81A900945DE2 /* Date+Formatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC57CE2CBF81A900945DE2 /* Date+Formatted.swift */; };
+		B3CC57D52CC067AB00945DE2 /* Separator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC57D32CC067AB00945DE2 /* Separator.swift */; };
+		B3CC57D72CC067B800945DE2 /* LabeledBorderedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC57D62CC067B800945DE2 /* LabeledBorderedText.swift */; };
+		B3CC57D92CC067CB00945DE2 /* BorderedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC57D82CC067CB00945DE2 /* BorderedText.swift */; };
+		B3CC57DF2CC0705800945DE2 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B3CC57DD2CC0705800945DE2 /* Localizable.xcstrings */; };
+		B3CC57E12CC0718B00945DE2 /* LocalizedStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC57E02CC0718B00945DE2 /* LocalizedStrings.swift */; };
 		B3CDD7012C766F2E00E558F8 /* ModuleStyleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CDD7002C766F2E00E558F8 /* ModuleStyleCell.swift */; };
 		B3CDD7032C767FD300E558F8 /* ModuleColorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CDD7022C767FD300E558F8 /* ModuleColorCell.swift */; };
 		B3CDD7072C77C59B00E558F8 /* ImageProcessingFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CDD7062C77C59B00E558F8 /* ImageProcessingFactory.swift */; };
@@ -575,6 +582,13 @@
 		B3CC57C42CBF393E00945DE2 /* TimeInterval+ToHoursAndMinutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ToHoursAndMinutes.swift"; sourceTree = "<group>"; };
 		B3CC57C62CBF394900945DE2 /* AsyncSequence+Collect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AsyncSequence+Collect.swift"; sourceTree = "<group>"; };
 		B3CC57C92CBF3C7F00945DE2 /* UsageActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageActivityView.swift; sourceTree = "<group>"; };
+		B3CC57CC2CBF7BD100945DE2 /* DeviceActivityReportAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DeviceActivityReportAssets.xcassets; sourceTree = "<group>"; };
+		B3CC57CE2CBF81A900945DE2 /* Date+Formatted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatted.swift"; sourceTree = "<group>"; };
+		B3CC57D32CC067AB00945DE2 /* Separator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Separator.swift; sourceTree = "<group>"; };
+		B3CC57D62CC067B800945DE2 /* LabeledBorderedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledBorderedText.swift; sourceTree = "<group>"; };
+		B3CC57D82CC067CB00945DE2 /* BorderedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderedText.swift; sourceTree = "<group>"; };
+		B3CC57DD2CC0705800945DE2 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		B3CC57E02CC0718B00945DE2 /* LocalizedStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedStrings.swift; sourceTree = "<group>"; };
 		B3CDD7002C766F2E00E558F8 /* ModuleStyleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleStyleCell.swift; sourceTree = "<group>"; };
 		B3CDD7022C767FD300E558F8 /* ModuleColorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleColorCell.swift; sourceTree = "<group>"; };
 		B3CDD7062C77C59B00E558F8 /* ImageProcessingFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProcessingFactory.swift; sourceTree = "<group>"; };
@@ -680,6 +694,8 @@
 		AF362C6A2CA7478B00506443 /* ModuliteDeviceActivityReport */ = {
 			isa = PBXGroup;
 			children = (
+				B3CC57DE2CC0705800945DE2 /* Localization */,
+				B3CC57CC2CBF7BD100945DE2 /* DeviceActivityReportAssets.xcassets */,
 				B3CC57CA2CBF3C7F00945DE2 /* Views */,
 				B3CC57BF2CBF38C200945DE2 /* Models */,
 				B3CC57BE2CBF38C200945DE2 /* Extensions */,
@@ -1788,6 +1804,7 @@
 			children = (
 				B3CC57C42CBF393E00945DE2 /* TimeInterval+ToHoursAndMinutes.swift */,
 				B3CC57C62CBF394900945DE2 /* AsyncSequence+Collect.swift */,
+				B3CC57CE2CBF81A900945DE2 /* Date+Formatted.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1804,9 +1821,29 @@
 		B3CC57CA2CBF3C7F00945DE2 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				B3CC57D42CC067AB00945DE2 /* Components */,
 				B3CC57C92CBF3C7F00945DE2 /* UsageActivityView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		B3CC57D42CC067AB00945DE2 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				B3CC57D32CC067AB00945DE2 /* Separator.swift */,
+				B3CC57D62CC067B800945DE2 /* LabeledBorderedText.swift */,
+				B3CC57D82CC067CB00945DE2 /* BorderedText.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		B3CC57DE2CC0705800945DE2 /* Localization */ = {
+			isa = PBXGroup;
+			children = (
+				B3CC57DD2CC0705800945DE2 /* Localizable.xcstrings */,
+				B3CC57E02CC0718B00945DE2 /* LocalizedStrings.swift */,
+			);
+			path = Localization;
 			sourceTree = "<group>";
 		};
 		B3CDD7052C77C51500E558F8 /* Factories */ = {
@@ -2157,7 +2194,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3CC57CD2CBF7BD100945DE2 /* DeviceActivityReportAssets.xcassets in Resources */,
 				B39A25E72CAFADF6001C76A5 /* BundleConfig.xcconfig in Resources */,
+				B3CC57DF2CC0705800945DE2 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2254,13 +2293,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3CC57C12CBF38D800945DE2 /* AppDeviceActivity.swift in Sources */,
+				B3CC57D92CC067CB00945DE2 /* BorderedText.swift in Sources */,
 				AFE5D5042CADD4C700503572 /* FamilyControlsManager.swift in Sources */,
 				AF362C6C2CA7478B00506443 /* UsageActivityReport.swift in Sources */,
 				B3CC57C52CBF393E00945DE2 /* TimeInterval+ToHoursAndMinutes.swift in Sources */,
 				B3CC57C32CBF38EB00945DE2 /* ActivityReport.swift in Sources */,
+				B3CC57D72CC067B800945DE2 /* LabeledBorderedText.swift in Sources */,
 				AF362C6D2CA7478B00506443 /* UsageActivityReportScene.swift in Sources */,
 				B3CC57CB2CBF3C7F00945DE2 /* UsageActivityView.swift in Sources */,
+				B3CC57E12CC0718B00945DE2 /* LocalizedStrings.swift in Sources */,
+				B3CC57D52CC067AB00945DE2 /* Separator.swift in Sources */,
 				B3CC57C72CBF394900945DE2 /* AsyncSequence+Collect.swift in Sources */,
+				B3CC57CF2CBF81A900945DE2 /* Date+Formatted.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Modulite/Screens/Usage/ViewController/UsageViewController.swift
+++ b/Modulite/Screens/Usage/ViewController/UsageViewController.swift
@@ -5,33 +5,16 @@ import SwiftUI
 
 class UsageViewController: UIViewController {
     
-    private var usageViewModel = UsageViewModel()
+    private let reportIdentifier = "TotalActivity"
+    
+    private var viewModel = UsageViewModel()
     
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let authCenter = AuthorizationCenter.shared
-        
-        Task {
-            do {
-                try await authCenter.requestAuthorization(for: .individual)
                 
-                let context: DeviceActivityReport.Context = .init("TotalActivity")
-                
-                let reportView = DeviceActivityReport(context)
-                let hostingController = UIHostingController(rootView: reportView)
-                
-                addChild(hostingController)
-                hostingController.view.frame = view.bounds
-                view.addSubview(hostingController.view)
-                hostingController.didMove(toParent: self)
-                
-            } catch {
-                print("Authorization Error")
-            }
-        }
+        fetchAndDisplayActivityReport()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -43,5 +26,68 @@ class UsageViewController: UIViewController {
     private func setupNavigationBar() {
         navigationItem.title = .localized(for: .usageViewControllerNavigationTitle)
         navigationController?.navigationBar.prefersLargeTitles = true
+    }
+    
+    private func fetchAndDisplayActivityReport() {
+        Task {
+            do {
+                try await viewModel.requestAuthorization()
+                
+                let reportView = await createDeviceActivityReport()
+                await displayReport(reportView)
+                
+            } catch {
+                await handleAuthorizationError(error)
+            }
+        }
+    }
+    
+    private func createDeviceActivityReport() async -> DeviceActivityReport {
+        let calendar = Calendar.current
+        let now = Date()
+        
+        guard let startOf7DaysAgo = calendar.date(
+            byAdding: .day,
+            value: -7,
+            to: calendar.startOfDay(for: now)
+        ) else {
+            fatalError("Failed to calculate start date for 7 days ago.")
+        }
+        
+        let filter = DeviceActivityFilter(
+            segment: .daily(
+                during: DateInterval(start: startOf7DaysAgo, end: now)
+            )
+        )
+        
+        let context = DeviceActivityReport.Context(reportIdentifier)
+        let reportView = DeviceActivityReport(context, filter: filter)
+        return reportView
+    }
+    
+    private func displayReport(_ reportView: DeviceActivityReport) async {
+        let hostingController = UIHostingController(rootView: reportView)
+        hostingController.view.backgroundColor = .whiteTurnip
+        
+        await MainActor.run {
+            addChild(hostingController)
+            hostingController.view.frame = view.bounds
+            hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            view.addSubview(hostingController.view)
+            hostingController.didMove(toParent: self)
+        }
+    }
+    
+    private func handleAuthorizationError(_ error: Error) async {
+        await MainActor.run {
+            let alert = UIAlertController(
+                title: "Authorization Error",
+                message: error.localizedDescription,
+                preferredStyle: .alert
+            )
+            
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            present(alert, animated: true)
+        }
     }
 }

--- a/Modulite/Screens/Usage/ViewModel/UsageViewModel.swift
+++ b/Modulite/Screens/Usage/ViewModel/UsageViewModel.swift
@@ -9,5 +9,9 @@ import Foundation
 import FamilyControls
 
 class UsageViewModel {
+    private let authCenter = AuthorizationCenter.shared
     
+    func requestAuthorization() async throws {
+        try await authCenter.requestAuthorization(for: .individual)
+    }
 }

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/blueberry.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/blueberry.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5F",
+          "green" : "0x4B",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7C",
+          "green" : "0x67",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/burntCoconut.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/burntCoconut.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x31",
+          "green" : "0x37",
+          "red" : "0x3A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/burntEnds.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/burntEnds.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x87",
+          "green" : "0x76",
+          "red" : "0x67"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/carrotOrange.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/carrotOrange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3B",
+          "green" : "0x75",
+          "red" : "0xCE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/charcoalGray.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/charcoalGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3C",
+          "green" : "0x3A",
+          "red" : "0x3A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/cupcake.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/cupcake.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x7F",
+          "red" : "0xD6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/eggYolk.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/eggYolk.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0xBA",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/fiestaGreen.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/fiestaGreen.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9B",
+          "green" : "0x98",
+          "red" : "0x4D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB0",
+          "green" : "0xB3",
+          "red" : "0x6D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/figBlue.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/figBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x78",
+          "green" : "0x6B",
+          "red" : "0x4B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x82",
+          "green" : "0x7B",
+          "red" : "0x68"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/iceCold.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/iceCold.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0x4C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/ketchupRed.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/ketchupRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x38",
+          "green" : "0x45",
+          "red" : "0xC6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/lemonYellow.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/lemonYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x48",
+          "green" : "0xAE",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/monsterGreen.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/monsterGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x38",
+          "green" : "0xFF",
+          "red" : "0x84"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/orangeJuice.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/orangeJuice.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x04",
+          "green" : "0x6E",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/potatoYellow.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/potatoYellow.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAF",
+          "green" : "0xD7",
+          "red" : "0xE9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3C",
+          "green" : "0x3A",
+          "red" : "0x3A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/sugarMint.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/sugarMint.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB5",
+          "green" : "0xF5",
+          "red" : "0x44"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/sweetTooth.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/sweetTooth.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xCF",
+          "red" : "0x7A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/textPrimary.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/textPrimary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/whiteTurnip.colorset/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Colors/whiteTurnip.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE6",
+          "green" : "0xF5",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x14",
+          "green" : "0x14",
+          "red" : "0x16"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Contents.json
+++ b/ModuliteDeviceActivityReport/DeviceActivityReportAssets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ModuliteDeviceActivityReport/Extensions/Date+Formatted.swift
+++ b/ModuliteDeviceActivityReport/Extensions/Date+Formatted.swift
@@ -8,6 +8,16 @@
 import Foundation
 
 extension Date {
+    static var today: Date {
+        Calendar.current.startOfDay(for: .now)
+    }
+    
+    static var yesterday: Date {
+        Calendar.current.date(byAdding: .day, value: -1, to: .now)!
+    }
+}
+
+extension Date {
     func formattedWithOrdinal(locale: Locale = Locale.current) -> String {
         let calendar = Calendar.current
         

--- a/ModuliteDeviceActivityReport/Extensions/Date+Formatted.swift
+++ b/ModuliteDeviceActivityReport/Extensions/Date+Formatted.swift
@@ -1,0 +1,44 @@
+//
+//  Date+Formatted.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 16/10/24.
+//
+
+import Foundation
+
+extension Date {
+    func formattedWithOrdinal(locale: Locale = Locale.current) -> String {
+        let calendar = Calendar.current
+        
+        let monthFormatter = DateFormatter()
+        monthFormatter.locale = locale
+        monthFormatter.setLocalizedDateFormatFromTemplate("MMM")
+        var month = monthFormatter.string(from: self)
+        if !month.hasSuffix(".") {
+            month.append(".")
+        }
+        
+        let day = calendar.component(.day, from: self)
+        let dayString = formattedDayWithOrdinal(day: day, locale: locale)
+        
+        let yearFormatter = DateFormatter()
+        yearFormatter.locale = locale
+        yearFormatter.setLocalizedDateFormatFromTemplate("yyyy")
+        let year = yearFormatter.string(from: self)
+        
+        return "\(month) \(dayString), \(year)"
+    }
+
+    private func formattedDayWithOrdinal(day: Int, locale: Locale) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .ordinal
+        numberFormatter.locale = locale
+
+        if let dayString = numberFormatter.string(from: NSNumber(value: day)) {
+            return dayString
+        } else {
+            return "\(day)"
+        }
+    }
+}

--- a/ModuliteDeviceActivityReport/Extensions/TimeInterval+ToHoursAndMinutes.swift
+++ b/ModuliteDeviceActivityReport/Extensions/TimeInterval+ToHoursAndMinutes.swift
@@ -14,4 +14,23 @@ extension TimeInterval {
         let hours = (time / 3600)
         return String(format: "%0.2d:%0.2d", hours, minutes)
     }
+    
+    func formattedWithUnits() -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .short
+        formatter.zeroFormattingBehavior = .dropAll
+        formatter.collapsesLargestUnit = false
+        formatter.maximumUnitCount = 2
+        
+        guard let formattedString = formatter.string(from: self) else {
+            return "0 min"
+        }
+                
+        let components = formattedString.split(separator: ",")
+        let spacedComponents = components.map { $0.trimmingCharacters(in: .whitespaces) }
+            .joined(separator: " ")
+        
+        return spacedComponents
+    }
 }

--- a/ModuliteDeviceActivityReport/Localization/Localizable.xcstrings
+++ b/ModuliteDeviceActivityReport/Localization/Localizable.xcstrings
@@ -1,0 +1,7 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+
+  },
+  "version" : "1.0"
+}

--- a/ModuliteDeviceActivityReport/Localization/Localizable.xcstrings
+++ b/ModuliteDeviceActivityReport/Localization/Localizable.xcstrings
@@ -1,7 +1,61 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-
+    "comparisonOverview" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comparison overview"
+          }
+        }
+      }
+    },
+    "onYourPhoneToday" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "on your phone today"
+          }
+        }
+      }
+    },
+    "screenTime7DaysAverage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your average in the last 7 days"
+          }
+        }
+      }
+    },
+    "screenTimeYesterday" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your screen time yesterday"
+          }
+        }
+      }
+    },
+    "youHaveSpent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have spent"
+          }
+        }
+      }
+    }
   },
   "version" : "1.0"
 }

--- a/ModuliteDeviceActivityReport/Localization/LocalizedStrings.swift
+++ b/ModuliteDeviceActivityReport/Localization/LocalizedStrings.swift
@@ -6,3 +6,56 @@
 //
 
 import Foundation
+
+protocol LocalizedKey {
+    var key: String { get }
+    var values: [CVarArg] { get }
+}
+
+extension LocalizedKey {
+    /// Computes the key for localization by extracting the case name from the enum instance.
+    /// Uses reflection to find the label of the first child of the enum case,
+    /// which represents the case name without associated values.
+    /// Falls back to the default description if no label is found.
+    var key: String {
+       if let nameRemovingValues = Mirror(reflecting: self).children.first?.label {
+           return nameRemovingValues
+       }
+       
+       return String(describing: self)
+   }
+   
+   /// Computes an array of `CVarArg` suitable for string formatting,
+   /// reflecting the associated values of the enum case.
+   /// Uses reflection to access and cast the associated values to `CVarArg` for use in formatted strings.
+   var values: [CVarArg] {
+       let mirror = Mirror(reflecting: self)
+       guard let associated = mirror.children.first?.value else { return [] }
+       
+       var extractedValues = [CVarArg]()
+       let valuesMirror = Mirror(reflecting: associated)
+       for child in valuesMirror.children {
+           if let array = child.value as? [CVarArg] {
+               extractedValues.append(contentsOf: array)
+           } else if let value = child.value as? CVarArg {
+               extractedValues.append(value)
+           }
+       }
+       
+       return extractedValues
+   }
+}
+
+extension String {
+    enum DeviceActivityReportTextKey: LocalizedKey {
+        case youHaveSpent
+        case onYourPhoneToday
+        case comparisonOverview
+        case screenTimeYesterday
+        case screenTime7DaysAverage
+    }
+    
+    static func localized(for key: DeviceActivityReportTextKey) -> String {
+        String(format: NSLocalizedString(key.key, comment: ""), arguments: key.values)
+    }
+}

--- a/ModuliteDeviceActivityReport/Localization/LocalizedStrings.swift
+++ b/ModuliteDeviceActivityReport/Localization/LocalizedStrings.swift
@@ -1,0 +1,8 @@
+//
+//  LocalizedStrings.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 16/10/24.
+//
+
+import Foundation

--- a/ModuliteDeviceActivityReport/Models/ActivityReport.swift
+++ b/ModuliteDeviceActivityReport/Models/ActivityReport.swift
@@ -8,6 +8,17 @@
 import Foundation
 
 struct ActivityReport {
-    let totalDuration: TimeInterval
-    let apps: [AppDeviceActivity]
+    let dailyUsage: [Date: TimeInterval]
+    let averageTimeLastWeek: TimeInterval
+    let appUsage: [Date: [AppDeviceActivity]]
+    
+    func formattedTime(for date: Date) -> String {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: date)
+        return dailyUsage[startOfDay]?.formattedWithUnits() ?? "-"
+    }
+    
+    var formattedAverageTimeLastWeek: String {
+        averageTimeLastWeek.formattedWithUnits()
+    }
 }

--- a/ModuliteDeviceActivityReport/UsageActivityReportScene.swift
+++ b/ModuliteDeviceActivityReport/UsageActivityReportScene.swift
@@ -13,35 +13,115 @@ extension DeviceActivityReport.Context {
 }
 
 struct UsageActivityReportScene: DeviceActivityReportScene {
-        
+    
     let context: DeviceActivityReport.Context = .totalActivity
     let content: (ActivityReport) -> UsageActivityView
     
+    /// Generates the configuration for the activity report based on the provided device activity results.
+    ///
+    /// - Parameter deviceActivityResults: The results of device activity data.
+    /// - Returns: An `ActivityReport` containing usage statistics and application activity for today.
     func makeConfiguration(
         representing deviceActivityResults: DeviceActivityResults<DeviceActivityData>
     ) async -> ActivityReport {
-        let totalDeviceActivityDuration = await deviceActivityResults
-            .flatMap { $0.activitySegments }
-            .reduce(0, { $0 + $1.totalActivityDuration })
         
-        let appActivityList = Array(
-            Set(
-                await deviceActivityResults
-                .flatMap { $0.activitySegments }
-                .flatMap { $0.categories }
-                .flatMap { $0.applications }
-                .map {
-                    AppDeviceActivity(
-                        id: $0.application.bundleIdentifier ?? "Unknown Bundle ID",
-                        displayName: $0.application.localizedDisplayName ?? "Unknown App",
-                        duration: $0.totalActivityDuration,
-                        numberOfPickups: $0.numberOfPickups
-                    )
-                }
-                .collect()
+        let calendar = Calendar.current
+        let dateIntervals = setupDateIntervals(calendar: calendar, now: .now)
+        
+        var dailyUsage: [Date: TimeInterval] = [:]
+        var appUsage: [Date: [AppDeviceActivity]] = [:]
+        
+        // Iterate over each activity segment to accumulate usage data.
+        for await activitySegment in deviceActivityResults.flatMap({ $0.activitySegments }) {
+            await processActivitySegment(
+                activitySegment,
+                calendar: calendar,
+                dateIntervals: dateIntervals,
+                dailyUsage: &dailyUsage,
+                appUsage: &appUsage
             )
-        ).sorted(by: { $0.duration > $1.duration })
+        }
         
-        return ActivityReport(totalDuration: totalDeviceActivityDuration, apps: appActivityList)
+        let averageTimeLastWeek = calculateAverageTime(
+            for: dailyUsage,
+            in: dateIntervals.last7DaysInterval
+        )
+        
+        return ActivityReport(
+            dailyUsage: dailyUsage,
+            averageTimeLastWeek: averageTimeLastWeek,
+            appUsage: appUsage
+        )
+    }
+    
+    /// Sets up the date intervals required for calculating usage statistics.
+    ///
+    /// - Parameters:
+    ///   - calendar: The calendar used for date calculations.
+    ///   - now: The current date and time.
+    /// - Returns: A tuple containing the interval for the last seven days and the start of today.
+    private func setupDateIntervals(
+        calendar: Calendar,
+        now: Date
+    ) -> (last7DaysInterval: DateInterval, startOfToday: Date) {
+        let startOfToday: Date = .today
+        
+        guard let startOf7DaysAgo = calendar.date(byAdding: .day, value: -7, to: startOfToday) else {
+            return (DateInterval(), startOfToday)
+        }
+        
+        let last7DaysInterval = DateInterval(start: startOf7DaysAgo, end: startOfToday)
+        return (last7DaysInterval, startOfToday)
+    }
+    
+    /// Processes an individual activity segment, updating usage statistics and tracking app activities per day.
+    ///
+    /// - Parameters:
+    ///   - activitySegment: The activity segment to process.
+    ///   - calendar: The calendar used for date comparisons.
+    ///   - dateIntervals: The date intervals defining the last seven days and the start of today.
+    ///   - dailyUsage: An inout dictionary accumulating daily usage times.
+    ///   - appUsage: An inout dictionary accumulating app activities per day.
+    private func processActivitySegment(
+        _ activitySegment: DeviceActivityData.ActivitySegment,
+        calendar: Calendar,
+        dateIntervals: (last7DaysInterval: DateInterval, startOfToday: Date),
+        dailyUsage: inout [Date: TimeInterval],
+        appUsage: inout [Date: [AppDeviceActivity]]
+    ) async {
+        let segmentStartDate = activitySegment.dateInterval.start
+        let segmentStartOfDay = calendar.startOfDay(for: segmentStartDate)
+        
+        // Accumulate daily usage for the last 7 days.
+        if dateIntervals.last7DaysInterval.contains(segmentStartDate) {
+            dailyUsage[segmentStartOfDay, default: 0] += activitySegment.totalActivityDuration
+        }
+        
+        // Accumulate app usage for the last 7 days.
+        guard dateIntervals.last7DaysInterval.contains(segmentStartDate) else { return }
+        
+        let apps = activitySegment.categories.flatMap { $0.applications }
+        let appActivities = await apps.map {
+            AppDeviceActivity(
+                id: $0.application.bundleIdentifier ?? "Unknown Bundle ID",
+                displayName: $0.application.localizedDisplayName ?? "Unknown App",
+                duration: $0.totalActivityDuration,
+                numberOfPickups: $0.numberOfPickups
+            )
+        }.collect()
+        
+        appUsage[segmentStartOfDay, default: []].append(contentsOf: appActivities)
+    }
+    
+    private func calculateAverageTime(
+        for dailyUsage: [Date: TimeInterval],
+        in last7DaysInterval: DateInterval
+    ) -> TimeInterval {
+        
+        let totalTimeLast7Days = dailyUsage
+            .filter { last7DaysInterval.contains($0.key) }
+            .reduce(0) { $0 + $1.value }
+        
+        return totalTimeLast7Days / 7
     }
 }

--- a/ModuliteDeviceActivityReport/Views/Components/BorderedText.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/BorderedText.swift
@@ -5,4 +5,30 @@
 //  Created by Gustavo Munhoz Correa on 16/10/24.
 //
 
-import Foundation
+import SwiftUI
+
+struct BorderedText: View {
+    var text: String = ""
+    var borderColor: Color = .carrotOrange
+    var textColor: Color = .carrotOrange
+    var maxWidth: CGFloat?
+    var verticalPadding: CGFloat = 6
+    var horizontalPadding: CGFloat = 12
+    var font: Font = .title3.bold()
+    var cornerRadius: CGFloat = 10
+    var lineWidth: CGFloat = 3
+
+    var body: some View {
+        Text(text)
+            .frame(maxWidth: maxWidth)
+            .padding(.vertical, verticalPadding)
+            .padding(.horizontal, horizontalPadding)
+            .font(font)
+            .foregroundColor(textColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(style: StrokeStyle(lineWidth: lineWidth))
+                    .fill(borderColor)
+            )
+    }
+}

--- a/ModuliteDeviceActivityReport/Views/Components/BorderedText.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/BorderedText.swift
@@ -1,0 +1,8 @@
+//
+//  BorderedText.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 16/10/24.
+//
+
+import Foundation

--- a/ModuliteDeviceActivityReport/Views/Components/LabeledBorderedText.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/LabeledBorderedText.swift
@@ -1,0 +1,8 @@
+//
+//  LabeledBorderedText.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 16/10/24.
+//
+
+import Foundation

--- a/ModuliteDeviceActivityReport/Views/Components/LabeledBorderedText.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/LabeledBorderedText.swift
@@ -5,4 +5,46 @@
 //  Created by Gustavo Munhoz Correa on 16/10/24.
 //
 
-import Foundation
+import SwiftUI
+
+struct LabeledBorderedText: View {
+    var labelText: String = ""
+    var labelTextColor: Color = .gray
+    var labelFont: Font = .callout.weight(.semibold)
+    var labelWidth: CGFloat? = 140
+    
+    var borderedText: String = ""
+    var borderedTextColor: Color = .textPrimary
+    var borderColor: Color = .gray
+    var borderedFont: Font = .body.bold()
+    var borderedTextWidth: CGFloat? = 125
+    var cornerRadius: CGFloat = 20
+    var borderWidth: CGFloat = 3
+    
+    var maxWidth: CGFloat? = .infinity
+    var borderedTextVerticalPadding: CGFloat = 12
+    
+    var body: some View {
+        VStack {
+            Text(labelText)
+                .font(labelFont)
+                .foregroundColor(labelTextColor)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .frame(width: labelWidth)
+                        
+            BorderedText(
+                text: borderedText,
+                borderColor: borderColor,
+                textColor: borderedTextColor,
+                maxWidth: maxWidth,
+                verticalPadding: borderedTextVerticalPadding,
+                font: borderedFont,
+                cornerRadius: cornerRadius,
+                lineWidth: borderWidth
+            )
+            .frame(width: borderedTextWidth)
+        }
+        .frame(maxWidth: maxWidth)
+    }
+}

--- a/ModuliteDeviceActivityReport/Views/Components/Separator.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/Separator.swift
@@ -1,0 +1,18 @@
+//
+//  Separator.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 16/10/24.
+//
+
+import SwiftUI
+
+struct Separator: View {
+    var body: some View {
+        Rectangle()
+            .fill(.potatoYellow)
+            .frame(height: 2)
+            .frame(maxWidth: .infinity)
+            .padding(24)
+    }
+}

--- a/ModuliteDeviceActivityReport/Views/Separator.swift
+++ b/ModuliteDeviceActivityReport/Views/Separator.swift
@@ -1,8 +1,0 @@
-//
-//  Separator.swift
-//  ModuliteDeviceActivityReport
-//
-//  Created by Gustavo Munhoz Correa on 16/10/24.
-//
-
-import Foundation

--- a/ModuliteDeviceActivityReport/Views/Separator.swift
+++ b/ModuliteDeviceActivityReport/Views/Separator.swift
@@ -1,0 +1,8 @@
+//
+//  Separator.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 16/10/24.
+//
+
+import Foundation

--- a/ModuliteDeviceActivityReport/Views/UsageActivityView.swift
+++ b/ModuliteDeviceActivityReport/Views/UsageActivityView.swift
@@ -11,29 +11,69 @@ struct UsageActivityView: View {
     var activityReport: ActivityReport
     
     var body: some View {
-        VStack {
-            Spacer(minLength: 50)
-            Text("Total Screen Time")
-            Spacer(minLength: 10)
-            Text(activityReport.totalDuration.toHoursAndMinutes())
-            List(activityReport.apps) { app in
-                ListRow(eachApp: app)
+        ScrollView {
+            VStack {
+                HStack {
+                    BorderedText(
+                        text: Date.today.formattedWithOrdinal(),
+                        maxWidth: 260
+                    )
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 24)
+                
+                Text(verbatim: .localized(for: .youHaveSpent))
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.gray)
+                
+                BorderedText(
+                    text: activityReport.formattedTime(for: .today),
+                    textColor: .textPrimary,
+                    verticalPadding: 26,
+                    horizontalPadding: 32,
+                    font: .largeTitle.bold(),
+                    cornerRadius: 20,
+                    lineWidth: 4
+                )
+                
+                Text(verbatim: .localized(for: .onYourPhoneToday))
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.gray)
+                
+                Separator()
+                
+                Text(verbatim: .localized(for: .comparisonOverview))
+                    .font(.title3.bold())
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                    .padding([.horizontal, .bottom], 24)
+                
+                HStack(alignment: .center) {
+                    Spacer()
+                    
+                    LabeledBorderedText(
+                        labelText: .localized(for: .screenTimeYesterday),
+                        borderedText: activityReport.formattedTime(for: .yesterday),
+                        borderColor: .ketchupRed
+                    )
+                    .padding(.trailing, -12)
+                    
+                    LabeledBorderedText(
+                        labelText: .localized(for: .screenTime7DaysAverage),
+                        labelWidth: 125,
+                        borderedText: activityReport.formattedAverageTimeLastWeek,
+                        borderColor: .fiestaGreen
+                    )
+                    .padding(.leading, -12)
+                    
+                    Spacer()
+                }
+                
+                Separator()
+                
+                Spacer()
             }
         }
-    }
-}
-
-struct ListRow: View {
-    var eachApp: AppDeviceActivity
-    var body: some View {
-        HStack {
-            Text(eachApp.displayName)
-            Spacer()
-            Text(eachApp.id)
-            Spacer()
-            Text("\(eachApp.numberOfPickups)")
-            Spacer()
-            Text(String(eachApp.duration.formatted()))
-        }
+        .scrollClipDisabled()
+        .padding(.vertical)
     }
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #170, adding the display of usage times in the `UsageActivityView`, with the view data provided by an extension of `ModuliteDeviceActivityReport`.

## Summary

1. **Usage Time Display in `UsageActivityView`**: Implemented the functionality to show detailed usage time information in the `UsageActivityView`. This helps users understand their app usage patterns over the last seven days, providing valuable insights into their device activity.

2. **Data Provided by Extension**: The `UsageActivityView` is powered by data from an extension of `ModuliteDeviceActivityReport`, which processes and formats the usage data to ensure it is presented clearly and informatively.

3. **Multi-Day Report Configuration**: Refactored the model to support multiple days of reports, allowing the `UsageActivityView` to display data from the last week, with a filter context specifically for the last 7 days.

4. **UI Enhancements**: Added localized texts, colors, and components to improve the look and feel of the `UsageActivityView`, ensuring a user-friendly presentation of the data.

## Testing

- Verified that the usage time information is displayed correctly in the `UsageActivityView`.
- Tested the date filtering and formatting extensions to confirm that they accurately present the data for the last seven days.
- Confirmed that the `UsageActivityView` integrates seamlessly with `ModuliteDeviceActivityReport` to provide real-time usage insights.