### PR TITLE
Added App Usage List to `UsageActivityView`

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		B32B610A2C8A4485007DDCE3 /* SelectAppsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32B61092C8A4485007DDCE3 /* SelectAppsView.swift */; };
 		B32B610C2C8A449C007DDCE3 /* SelectAppsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32B610B2C8A449C007DDCE3 /* SelectAppsViewController.swift */; };
 		B32B61102C8A474B007DDCE3 /* SelectAppsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32B610F2C8A474B007DDCE3 /* SelectAppsViewModel.swift */; };
+		B338088D2CC1902E00D56884 /* AppUsageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338088C2CC1902E00D56884 /* AppUsageItem.swift */; };
+		B338088F2CC1905500D56884 /* AppUsageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338088E2CC1905500D56884 /* AppUsageList.swift */; };
 		B34F3DF02C66EACE0041D7BD /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = B34F3DEF2C66EACE0041D7BD /* SnapKit */; };
 		B34F3DF32C6701740041D7BD /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B34F3DF22C6701740041D7BD /* Localizable.xcstrings */; };
 		B34F3DF52C6701870041D7BD /* String+LocalizedKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34F3DF42C6701870041D7BD /* String+LocalizedKey.swift */; };
@@ -436,6 +438,8 @@
 		B32B61092C8A4485007DDCE3 /* SelectAppsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAppsView.swift; sourceTree = "<group>"; };
 		B32B610B2C8A449C007DDCE3 /* SelectAppsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAppsViewController.swift; sourceTree = "<group>"; };
 		B32B610F2C8A474B007DDCE3 /* SelectAppsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAppsViewModel.swift; sourceTree = "<group>"; };
+		B338088C2CC1902E00D56884 /* AppUsageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUsageItem.swift; sourceTree = "<group>"; };
+		B338088E2CC1905500D56884 /* AppUsageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUsageList.swift; sourceTree = "<group>"; };
 		B34F3DF22C6701740041D7BD /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		B34F3DF42C6701870041D7BD /* String+LocalizedKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+LocalizedKey.swift"; sourceTree = "<group>"; };
 		B34F3DF72C69A3810041D7BD /* DebugOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOptions.swift; sourceTree = "<group>"; };
@@ -1833,6 +1837,8 @@
 				B3CC57D32CC067AB00945DE2 /* Separator.swift */,
 				B3CC57D62CC067B800945DE2 /* LabeledBorderedText.swift */,
 				B3CC57D82CC067CB00945DE2 /* BorderedText.swift */,
+				B338088C2CC1902E00D56884 /* AppUsageItem.swift */,
+				B338088E2CC1905500D56884 /* AppUsageList.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2300,6 +2306,8 @@
 				B3CC57C32CBF38EB00945DE2 /* ActivityReport.swift in Sources */,
 				B3CC57D72CC067B800945DE2 /* LabeledBorderedText.swift in Sources */,
 				AF362C6D2CA7478B00506443 /* UsageActivityReportScene.swift in Sources */,
+				B338088D2CC1902E00D56884 /* AppUsageItem.swift in Sources */,
+				B338088F2CC1905500D56884 /* AppUsageList.swift in Sources */,
 				B3CC57CB2CBF3C7F00945DE2 /* UsageActivityView.swift in Sources */,
 				B3CC57E12CC0718B00945DE2 /* LocalizedStrings.swift in Sources */,
 				B3CC57D52CC067AB00945DE2 /* Separator.swift in Sources */,

--- a/ModuliteDeviceActivityReport/Extensions/TimeInterval+ToHoursAndMinutes.swift
+++ b/ModuliteDeviceActivityReport/Extensions/TimeInterval+ToHoursAndMinutes.swift
@@ -8,6 +8,15 @@
 import Foundation
 
 extension TimeInterval {
+    func formattedAsMinutes() -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute]
+        formatter.unitsStyle = .short
+        formatter.zeroFormattingBehavior = .dropAll
+        
+        return formatter.string(from: self) ?? "0 min"
+    }
+    
     func toHoursAndMinutes() -> String {
         let time = NSInteger(self)
         let minutes = (time / 60) % 60
@@ -26,7 +35,7 @@ extension TimeInterval {
         guard let formattedString = formatter.string(from: self) else {
             return "0 min"
         }
-                
+        
         let components = formattedString.split(separator: ",")
         let spacedComponents = components.map { $0.trimmingCharacters(in: .whitespaces) }
             .joined(separator: " ")

--- a/ModuliteDeviceActivityReport/Localization/Localizable.xcstrings
+++ b/ModuliteDeviceActivityReport/Localization/Localizable.xcstrings
@@ -12,6 +12,17 @@
         }
       }
     },
+    "howYouveSpentYourTime" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How you’ve spent your time"
+          }
+        }
+      }
+    },
     "onYourPhoneToday" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/ModuliteDeviceActivityReport/Localization/LocalizedStrings.swift
+++ b/ModuliteDeviceActivityReport/Localization/LocalizedStrings.swift
@@ -53,6 +53,7 @@ extension String {
         case comparisonOverview
         case screenTimeYesterday
         case screenTime7DaysAverage
+        case howYouveSpentYourTime
     }
     
     static func localized(for key: DeviceActivityReportTextKey) -> String {

--- a/ModuliteDeviceActivityReport/Models/ActivityReport.swift
+++ b/ModuliteDeviceActivityReport/Models/ActivityReport.swift
@@ -21,4 +21,10 @@ struct ActivityReport {
     var formattedAverageTimeLastWeek: String {
         averageTimeLastWeek.formattedWithUnits()
     }
+    
+    func relevantApps(for date: Date) -> [AppDeviceActivity] {
+        (appUsage[date] ?? [])
+            .filter { $0.duration > 60}
+            .sorted(by: { $0.duration > $1.duration })
+    }
 }

--- a/ModuliteDeviceActivityReport/Models/AppDeviceActivity.swift
+++ b/ModuliteDeviceActivityReport/Models/AppDeviceActivity.swift
@@ -6,9 +6,11 @@
 //
 
 import Foundation
+import ManagedSettings
 
 struct AppDeviceActivity: Identifiable, Hashable {
     var id: String
+    var token: ApplicationToken?
     var displayName: String
     var duration: TimeInterval
     var numberOfPickups: Int

--- a/ModuliteDeviceActivityReport/UsageActivityReportScene.swift
+++ b/ModuliteDeviceActivityReport/UsageActivityReportScene.swift
@@ -104,6 +104,7 @@ struct UsageActivityReportScene: DeviceActivityReportScene {
         let appActivities = await apps.map {
             AppDeviceActivity(
                 id: $0.application.bundleIdentifier ?? "Unknown Bundle ID",
+                token: $0.application.token,
                 displayName: $0.application.localizedDisplayName ?? "Unknown App",
                 duration: $0.totalActivityDuration,
                 numberOfPickups: $0.numberOfPickups

--- a/ModuliteDeviceActivityReport/Views/Components/AppUsageItem.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/AppUsageItem.swift
@@ -1,0 +1,8 @@
+//
+//  AppUsageItem.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 17/10/24.
+//
+
+import Foundation

--- a/ModuliteDeviceActivityReport/Views/Components/AppUsageItem.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/AppUsageItem.swift
@@ -5,4 +5,38 @@
 //  Created by Gustavo Munhoz Correa on 17/10/24.
 //
 
-import Foundation
+import SwiftUI
+
+struct AppUsageItem: View {
+    var app: AppDeviceActivity
+    var usagePercentage: Double
+
+    var body: some View {
+        HStack(spacing: 20) {
+            if let token = app.token {
+                Label(token)
+                    .labelStyle(.iconOnly)
+                    .scaleEffect(1.75)
+            }
+            
+            VStack(alignment: .leading, spacing: 1) {
+                Text(app.displayName)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                 
+                HStack(spacing: 16) {
+                    GeometryReader { geometry in
+                        RoundedRectangle(cornerRadius: 8)
+                            .frame(width: CGFloat(usagePercentage) * geometry.size.width)
+                            .foregroundColor(.carrotOrange)
+                    }
+                    .frame(height: 12)
+                    
+                    Text(app.duration.formattedAsMinutes())
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(.gray)
+                }
+            }
+        }
+    }
+}

--- a/ModuliteDeviceActivityReport/Views/Components/AppUsageList.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/AppUsageList.swift
@@ -5,4 +5,34 @@
 //  Created by Gustavo Munhoz Correa on 17/10/24.
 //
 
-import Foundation
+import SwiftUI
+
+struct AppUsageList: View {
+    var apps: [AppDeviceActivity]
+    
+    var body: some View {
+        let totalDuration = apps.totalDuration
+        
+        ForEach(apps) { app in
+            let rawPercentage = totalDuration > 0 ? (app.duration / totalDuration) : 0
+            let scaledPercentage = scaleLogarithmic(rawPercentage)
+            
+            AppUsageItem(app: app, usagePercentage: scaledPercentage)
+                .padding(.bottom, 20)
+        }
+        .padding(.horizontal, 24)
+    }
+    
+    private func scaleLogarithmic(_ percentage: Double) -> Double {
+        let adjustedValue = max(percentage, 0.01)
+        let logValue = (log(adjustedValue + 1.015) / log(1.5)) * 1.05
+        
+        return min(logValue, 1.0)
+    }
+}
+
+extension Array where Element == AppDeviceActivity {
+    var totalDuration: TimeInterval {
+        reduce(0) { $0 + $1.duration }
+    }
+}

--- a/ModuliteDeviceActivityReport/Views/Components/AppUsageList.swift
+++ b/ModuliteDeviceActivityReport/Views/Components/AppUsageList.swift
@@ -1,0 +1,8 @@
+//
+//  AppUsageList.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 17/10/24.
+//
+
+import Foundation

--- a/ModuliteDeviceActivityReport/Views/UsageActivityView.swift
+++ b/ModuliteDeviceActivityReport/Views/UsageActivityView.swift
@@ -69,11 +69,19 @@ struct UsageActivityView: View {
                 }
                 
                 Separator()
+
+                Text(verbatim: .localized(for: .howYouveSpentYourTime))
+                    .font(.title2.bold())
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding([.horizontal, .bottom], 24)
                 
-                Spacer()
+                AppUsageList(
+                    apps: activityReport.relevantApps(for: .today)
+                )
             }
+            .background(.whiteTurnip)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical)
         }
-        .scrollClipDisabled()
-        .padding(.vertical)
     }
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #171, adding an app usage list to the `UsageActivityView`.

## Summary

1. **Implemented App Usage List**: Added a list to the `UsageActivityView` that displays statistics for individual app usage. This helps users understand how much time they are spending on each app, enhancing their insights into daily app activities.

2. **`AppUsageItem` for Showing App Stats**: Created an `AppUsageItem` component to represent each app in the list. This component includes details such as app name, icon, and usage duration, providing users with clear and informative stats at a glance.

3. **App Icon Retrieval**: Introduced a `token` property to retrieve and display app icons in the list, making the app usage stats visually identifiable.

4. **Localized Titles and Filtering by Usage Time**: Added localized titles for the app usage list and implemented a method to filter apps by usage time, allowing users to easily see which apps they use the most.

## Testing

- Verified that the app usage list is correctly displayed within the `UsageActivityView`.
- Confirmed that each `AppUsageItem` shows the correct app icon, name, and usage time.
- Tested the filtering functionality to ensure the list accurately represents the apps with the highest usage.