### PR TITLE
Implemented Stats for Multiple Days

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		B32B61102C8A474B007DDCE3 /* SelectAppsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32B610F2C8A474B007DDCE3 /* SelectAppsViewModel.swift */; };
 		B338088D2CC1902E00D56884 /* AppUsageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338088C2CC1902E00D56884 /* AppUsageItem.swift */; };
 		B338088F2CC1905500D56884 /* AppUsageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338088E2CC1905500D56884 /* AppUsageList.swift */; };
+		B33808912CC19E6500D56884 /* Date+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33808902CC19E6500D56884 /* Date+Operations.swift */; };
 		B34F3DF02C66EACE0041D7BD /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = B34F3DEF2C66EACE0041D7BD /* SnapKit */; };
 		B34F3DF32C6701740041D7BD /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B34F3DF22C6701740041D7BD /* Localizable.xcstrings */; };
 		B34F3DF52C6701870041D7BD /* String+LocalizedKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34F3DF42C6701870041D7BD /* String+LocalizedKey.swift */; };
@@ -440,6 +441,7 @@
 		B32B610F2C8A474B007DDCE3 /* SelectAppsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAppsViewModel.swift; sourceTree = "<group>"; };
 		B338088C2CC1902E00D56884 /* AppUsageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUsageItem.swift; sourceTree = "<group>"; };
 		B338088E2CC1905500D56884 /* AppUsageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUsageList.swift; sourceTree = "<group>"; };
+		B33808902CC19E6500D56884 /* Date+Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Operations.swift"; sourceTree = "<group>"; };
 		B34F3DF22C6701740041D7BD /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		B34F3DF42C6701870041D7BD /* String+LocalizedKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+LocalizedKey.swift"; sourceTree = "<group>"; };
 		B34F3DF72C69A3810041D7BD /* DebugOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOptions.swift; sourceTree = "<group>"; };
@@ -1809,6 +1811,7 @@
 				B3CC57C42CBF393E00945DE2 /* TimeInterval+ToHoursAndMinutes.swift */,
 				B3CC57C62CBF394900945DE2 /* AsyncSequence+Collect.swift */,
 				B3CC57CE2CBF81A900945DE2 /* Date+Formatted.swift */,
+				B33808902CC19E6500D56884 /* Date+Operations.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2311,6 +2314,7 @@
 				B3CC57CB2CBF3C7F00945DE2 /* UsageActivityView.swift in Sources */,
 				B3CC57E12CC0718B00945DE2 /* LocalizedStrings.swift in Sources */,
 				B3CC57D52CC067AB00945DE2 /* Separator.swift in Sources */,
+				B33808912CC19E6500D56884 /* Date+Operations.swift in Sources */,
 				B3CC57C72CBF394900945DE2 /* AsyncSequence+Collect.swift in Sources */,
 				B3CC57CF2CBF81A900945DE2 /* Date+Formatted.swift in Sources */,
 			);

--- a/ModuliteDeviceActivityReport/Extensions/Date+Formatted.swift
+++ b/ModuliteDeviceActivityReport/Extensions/Date+Formatted.swift
@@ -8,6 +8,23 @@
 import Foundation
 
 extension Date {
+    func formattedWithDayAndMonth(locale: Locale = Locale.current) -> String {
+        let calendar = Calendar.current
+        
+        let monthFormatter = DateFormatter()
+        monthFormatter.locale = locale
+        monthFormatter.setLocalizedDateFormatFromTemplate("MMM")
+        var month = monthFormatter.string(from: self)
+        if !month.hasSuffix(".") {
+            month.append(".")
+        }
+        
+        let day = calendar.component(.day, from: self)
+        let dayString = formattedDayWithOrdinal(day: day, locale: locale)
+        
+        return "\(month) \(dayString)"
+    }
+    
     func formattedWithOrdinal(locale: Locale = Locale.current) -> String {
         let calendar = Calendar.current
         

--- a/ModuliteDeviceActivityReport/Extensions/Date+Formatted.swift
+++ b/ModuliteDeviceActivityReport/Extensions/Date+Formatted.swift
@@ -8,16 +8,6 @@
 import Foundation
 
 extension Date {
-    static var today: Date {
-        Calendar.current.startOfDay(for: .now)
-    }
-    
-    static var yesterday: Date {
-        Calendar.current.date(byAdding: .day, value: -1, to: .now)!
-    }
-}
-
-extension Date {
     func formattedWithOrdinal(locale: Locale = Locale.current) -> String {
         let calendar = Calendar.current
         

--- a/ModuliteDeviceActivityReport/Extensions/Date+Operations.swift
+++ b/ModuliteDeviceActivityReport/Extensions/Date+Operations.swift
@@ -1,0 +1,34 @@
+//
+//  Date+Operations.swift
+//  ModuliteDeviceActivityReport
+//
+//  Created by Gustavo Munhoz Correa on 17/10/24.
+//
+
+import Foundation
+
+extension Date {
+    static var today: Date {
+        Calendar.current.startOfDay(for: .now)
+    }
+    
+    static var yesterday: Date {
+        Calendar.current.date(byAdding: .day, value: -1, to: .now)!
+    }
+    
+    func subtractingDays(_ days: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: -days, to: self)!
+    }
+    
+    func subtractOneDay() -> Date {
+        Calendar.current.date(byAdding: .day, value: -1, to: self)!
+    }
+    
+    func addingDays(_ days: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: days, to: self)!
+    }
+    
+    func addOneDay() -> Date {
+        Calendar.current.date(byAdding: .day, value: 1, to: self)!
+    }
+}

--- a/ModuliteDeviceActivityReport/Localization/Localizable.xcstrings
+++ b/ModuliteDeviceActivityReport/Localization/Localizable.xcstrings
@@ -23,6 +23,17 @@
         }
       }
     },
+    "onYourPhoneAt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "on your phone at %@"
+          }
+        }
+      }
+    },
     "onYourPhoneToday" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -45,6 +56,17 @@
         }
       }
     },
+    "screenTimeDayBefore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your screen time the day before"
+          }
+        }
+      }
+    },
     "screenTimeYesterday" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -63,6 +85,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "You have spent"
+          }
+        }
+      }
+    },
+    "youSpent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You spent"
           }
         }
       }

--- a/ModuliteDeviceActivityReport/Localization/LocalizedStrings.swift
+++ b/ModuliteDeviceActivityReport/Localization/LocalizedStrings.swift
@@ -49,9 +49,12 @@ extension LocalizedKey {
 extension String {
     enum DeviceActivityReportTextKey: LocalizedKey {
         case youHaveSpent
+        case youSpent
+        case onYourPhoneAt(date: String)
         case onYourPhoneToday
         case comparisonOverview
         case screenTimeYesterday
+        case screenTimeDayBefore
         case screenTime7DaysAverage
         case howYouveSpentYourTime
     }

--- a/ModuliteDeviceActivityReport/Models/ActivityReport.swift
+++ b/ModuliteDeviceActivityReport/Models/ActivityReport.swift
@@ -27,4 +27,8 @@ struct ActivityReport {
             .filter { $0.duration > 60}
             .sorted(by: { $0.duration > $1.duration })
     }
+    
+    func isPreviousDateUseLessThan(date: Date) -> Bool {
+        (dailyUsage[date] ?? 0) < (dailyUsage[date.subtractOneDay()] ?? 0)
+    }
 }

--- a/ModuliteDeviceActivityReport/Views/UsageActivityView.swift
+++ b/ModuliteDeviceActivityReport/Views/UsageActivityView.swift
@@ -102,7 +102,11 @@ struct UsageActivityView: View {
     
     var mainScreenTimeLabel: some View {
         VStack {
-            Text(verbatim: .localized(for: .youHaveSpent))
+            Text(
+                verbatim: .localized(
+                    for: currentDate == .today ? .youHaveSpent : .youSpent
+                )
+            )
                 .font(.body.weight(.semibold))
                 .foregroundStyle(.gray)
             
@@ -116,7 +120,14 @@ struct UsageActivityView: View {
                 lineWidth: 4
             )
             
-            Text(verbatim: .localized(for: .onYourPhoneToday))
+            Text(
+                verbatim: .localized(
+                    for: currentDate == .today ?
+                        .onYourPhoneToday : .onYourPhoneAt(
+                            date: currentDate.formattedWithDayAndMonth()
+                        )
+                )
+            )
                 .font(.body.weight(.semibold))
                 .foregroundStyle(.gray)
         }
@@ -133,7 +144,10 @@ struct UsageActivityView: View {
                 Spacer()
                 
                 LabeledBorderedText(
-                    labelText: .localized(for: .screenTimeYesterday),
+                    labelText: .localized(
+                        for: currentDate == .today ?
+                            .screenTimeYesterday : .screenTimeDayBefore
+                    ),
                     borderedText: activityReport.formattedTime(
                         for: currentDate.subtractOneDay()
                     ),

--- a/ModuliteDeviceActivityReport/Views/UsageActivityView.swift
+++ b/ModuliteDeviceActivityReport/Views/UsageActivityView.swift
@@ -8,80 +8,162 @@
 import SwiftUI
 
 struct UsageActivityView: View {
+    // MARK: - Properties
+    
+    @State var currentDate: Date = .today {
+        didSet {
+            canAddDay = currentDate < .today
+            canSubtractDay = currentDate > .today.subtractingDays(7)
+        }
+    }
+    @State var previousDate: Date = .today
+    @State private var animateLeft = false
+    @State private var animateRight = false
+    
+    @State private var canAddDay: Bool = false
+    @State private var canSubtractDay: Bool = true
+    
     var activityReport: ActivityReport
     
+    // MARK: - Body
     var body: some View {
-        ScrollView {
-            VStack {
-                HStack {
-                    BorderedText(
-                        text: Date.today.formattedWithOrdinal(),
-                        maxWidth: 260
-                    )
+        VStack {
+            dateHeader
+            
+            ScrollView {
+                VStack {
+                    mainScreenTimeLabel
+                    
+                    Separator()
+                    
+                    comparisonOverview
+                    
+                    Separator()
+                    
+                    appUsageList
                 }
-                .padding(.horizontal)
-                .padding(.bottom, 24)
-                
-                Text(verbatim: .localized(for: .youHaveSpent))
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(.gray)
-                
-                BorderedText(
-                    text: activityReport.formattedTime(for: .today),
-                    textColor: .textPrimary,
-                    verticalPadding: 26,
-                    horizontalPadding: 32,
-                    font: .largeTitle.bold(),
-                    cornerRadius: 20,
-                    lineWidth: 4
-                )
-                
-                Text(verbatim: .localized(for: .onYourPhoneToday))
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(.gray)
-                
-                Separator()
-                
-                Text(verbatim: .localized(for: .comparisonOverview))
-                    .font(.title3.bold())
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .padding([.horizontal, .bottom], 24)
-                
-                HStack(alignment: .center) {
-                    Spacer()
-                    
-                    LabeledBorderedText(
-                        labelText: .localized(for: .screenTimeYesterday),
-                        borderedText: activityReport.formattedTime(for: .yesterday),
-                        borderColor: .ketchupRed
-                    )
-                    .padding(.trailing, -12)
-                    
-                    LabeledBorderedText(
-                        labelText: .localized(for: .screenTime7DaysAverage),
-                        labelWidth: 125,
-                        borderedText: activityReport.formattedAverageTimeLastWeek,
-                        borderColor: .fiestaGreen
-                    )
-                    .padding(.leading, -12)
-                    
-                    Spacer()
-                }
-                
-                Separator()
-
-                Text(verbatim: .localized(for: .howYouveSpentYourTime))
-                    .font(.title2.bold())
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding([.horizontal, .bottom], 24)
-                
-                AppUsageList(
-                    apps: activityReport.relevantApps(for: .today)
-                )
+                .background(.whiteTurnip)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical)
             }
-            .background(.whiteTurnip)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical)
+        }
+    }
+    
+    // MARK: - Subviews
+    var dateHeader: some View {
+        HStack {
+            Button {
+                guard canSubtractDay else { return }
+                
+                withAnimation {
+                    previousDate = currentDate
+                    currentDate = currentDate.subtractOneDay()
+                    animateLeft = true
+                    animateRight = false
+                }
+            } label: {
+                Image(systemName: "arrow.left.circle")
+                    .font(.title.weight(.semibold))
+                    .foregroundStyle(canSubtractDay ? .carrotOrange : .gray)
+                    .symbolEffect(.bounce, options: .speed(2), value: animateLeft)
+            }
+            .disabled(!canSubtractDay)
+            
+            BorderedText(
+                text: currentDate.formattedWithOrdinal(),
+                maxWidth: 260
+            )
+            
+            Button {
+                guard canAddDay else { return }
+                
+                withAnimation {
+                    previousDate = currentDate
+                    currentDate = currentDate.addOneDay()
+                    animateRight = true
+                    animateLeft = false
+                }
+            } label: {
+                Image(systemName: "arrow.right.circle")
+                    .font(.title.weight(.semibold))
+                    .foregroundStyle(canAddDay ? .carrotOrange : .gray)
+                    .symbolEffect(.bounce, options: .speed(2), value: animateRight)
+            }
+            .disabled(!canAddDay)
+        }
+        .onChange(of: currentDate) {
+            DispatchQueue.main.asyncAfter(deadline: .now()) {
+                animateLeft = false
+                animateRight = false
+            }
+        }
+        .padding(24)
+    }
+    
+    var mainScreenTimeLabel: some View {
+        VStack {
+            Text(verbatim: .localized(for: .youHaveSpent))
+                .font(.body.weight(.semibold))
+                .foregroundStyle(.gray)
+            
+            BorderedText(
+                text: activityReport.formattedTime(for: currentDate),
+                textColor: .textPrimary,
+                verticalPadding: 26,
+                horizontalPadding: 32,
+                font: .largeTitle.bold(),
+                cornerRadius: 20,
+                lineWidth: 4
+            )
+            
+            Text(verbatim: .localized(for: .onYourPhoneToday))
+                .font(.body.weight(.semibold))
+                .foregroundStyle(.gray)
+        }
+    }
+    
+    var comparisonOverview: some View {
+        VStack {
+            Text(verbatim: .localized(for: .comparisonOverview))
+                .font(.title3.bold())
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding([.horizontal, .bottom], 24)
+            
+            HStack(alignment: .center) {
+                Spacer()
+                
+                LabeledBorderedText(
+                    labelText: .localized(for: .screenTimeYesterday),
+                    borderedText: activityReport.formattedTime(
+                        for: currentDate.subtractOneDay()
+                    ),
+                    borderColor: .ketchupRed
+                )
+                .padding(.trailing, -12)
+                
+                LabeledBorderedText(
+                    labelText: .localized(for: .screenTime7DaysAverage),
+                    labelWidth: 125,
+                    borderedText: activityReport.formattedAverageTimeLastWeek,
+                    borderColor: .fiestaGreen
+                )
+                .padding(.leading, -12)
+                
+                Spacer()
+            }
+        }
+    }
+    
+    var appUsageList: some View {
+        VStack {
+            Text(verbatim: .localized(for: .howYouveSpentYourTime))
+                .font(.title2.bold())
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding([.horizontal, .bottom], 24)
+            
+            AppUsageList(
+                apps: activityReport.relevantApps(for: currentDate)
+            )
         }
     }
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #167, implementing support for displaying statistics for multiple dates.

## Summary

1. **Reports by Date**: Added functionality to generate and display reports for different dates, not just the current day. This allows users to view historical data and better understand usage trends over time.

2. **Date Representation Improvements**: Introduced a method to represent dates as **month and day**, providing a clear and concise way for users to identify which day's stats are being viewed.

3. **Localized Texts for Date-Based Reports**: Added localized texts for days other than today, ensuring that users see accurate and easily understandable date representations in their preferred language.

4. **Comparison with Previous Day**: Implemented a comparison mechanism to show how current stats relate to the previous day's data. This comparison helps users visualize improvements or declines in their usage.

5. **Dynamic Border Color for Usage**: Updated the main usage view to change the border color based on the comparison with the previous day, offering a visual indication of changes in usage (e.g., increased or decreased activity).

## Testing

- Verified that stats can be displayed correctly for any selected date.
- Tested the date representation and localization to ensure consistency across different languages and regions.
- Confirmed that the border color changes dynamically based on the comparison with the previous day's data.