### PR TITLE
Implemented Separator To Apps In `SelectAppsView`

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/SelectApps/View/AppCollectionViewCell.swift
+++ b/Modulite/Screens/WidgetConfiguration/SelectApps/View/AppCollectionViewCell.swift
@@ -50,7 +50,9 @@ class AppCollectionViewCell: UICollectionViewCell {
         
         return label
     }()
-        
+    
+    private let separator = SeparatorView()
+    
     // MARK: - Setup methods
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -86,6 +88,7 @@ class AppCollectionViewCell: UICollectionViewCell {
     private func addSubviews() {
         addSubview(selectedImageView)
         addSubview(appNameLabel)
+        addSubview(separator)
     }
     
     private func setupContraints() {
@@ -97,6 +100,11 @@ class AppCollectionViewCell: UICollectionViewCell {
         appNameLabel.snp.makeConstraints { make in
             make.left.equalTo(selectedImageView.snp.right).offset(15)
             make.right.top.bottom.equalToSuperview()
+        }
+        
+        separator.snp.makeConstraints { make in
+            make.left.right.equalToSuperview()
+            make.bottom.equalToSuperview()
         }
     }
     

--- a/Modulite/Screens/WidgetConfiguration/SelectApps/View/SelectAppsView.swift
+++ b/Modulite/Screens/WidgetConfiguration/SelectApps/View/SelectAppsView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import SwiftUI
 
 class SelectAppsView: UIView {
     
@@ -71,9 +72,9 @@ class SelectAppsView: UIView {
     
     private(set) lazy var appsCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
-        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 52, height: 32)
+        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 52, height: 44)
         layout.scrollDirection = .vertical
-        layout.minimumLineSpacing = 4
+        layout.minimumLineSpacing = 0
         
         let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
         view.backgroundColor = .clear
@@ -167,5 +168,16 @@ class SelectAppsView: UIView {
     
     func updateAppCountText(to count: Int) {
         appsSelectedLabel.text = .localized(for: .selectAppsViewAppsSelected(count: count))
+        
+        updateSelectedLabelBorderColor(for: count)
+    }
+    
+    func updateSelectedLabelBorderColor(for count: Int) {
+        UIView.animate(withDuration: 0.25) { [weak self] in
+            guard let self = self else { return }
+            
+            self.appsSelectedLabel.layer.borderColor =
+            count > 0 ? UIColor.fiestaGreen.cgColor : UIColor.ketchupRed.cgColor
+        }
     }
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #184, adding separators in `AppCollectionViewCell` and an animated border for `appsSelectedLabel` in `SelectAppsView`.

## Summary

1. **Separators in `AppCollectionViewCell`**: Added separators between items in `AppCollectionViewCell` to provide a more structured and visually distinct layout. This makes it easier for users to differentiate between individual apps in the collection.

2. **Animated Border for `appsSelectedLabel`**: Implemented an animated border for `appsSelectedLabel` in `SelectAppsView`. The animation triggers when apps are selected, enhancing visual feedback and improving the overall user interaction by highlighting the selected state in a more dynamic way.

## Testing

- Tested the animated border for `appsSelectedLabel` to ensure it triggers as expected when apps are selected, and the animation is smooth.
- Confirmed that both the separators and animated border work well in both light and dark modes.