### PR TITLE
Update TabBar to Widgets and Improve Page Selection UX

### DIFF
--- a/Modulite/Coordinators/RootTabCoordinator.swift
+++ b/Modulite/Coordinators/RootTabCoordinator.swift
@@ -39,33 +39,34 @@ class RootTabCoordinator: Coordinator {
     /// - Parameter rootTabBarController: The root tab bar controller to configure.
     private func setupTabs(for rootTabBarController: RootTabBarController) {
         rootTabBarController.viewControllers = [
-            configureHome(),
+            configureWidgets(),
             configureUsage(),
             configureBlockApps(),
             configureSettings()
         ]
     }
 
-    /// Creates and configures the Home tab with a navigation controller.
-    /// - Returns: A configured navigation controller for the Home tab.
-    private func configureHome() -> UINavigationController {
+    /// Creates and configures the Widgets tab with a navigation controller.
+    /// This tab focuses on all widgets settings
+    /// - Returns: A configured navigation controller for the Widgets tab.
+    private func configureWidgets() -> UINavigationController {
         let viewController = HomeViewController()
         let navigationController = UINavigationController(rootViewController: viewController)
         
         let tabBarItem = createTabBarItem(
             titleKey: .homeViewControllerTabBarItemTitle,
-            imageName: "house.fill",
-            selectedImageName: "house.fill"
+            imageName: "square.grid.3x2.fill",
+            selectedImageName: "square.grid.3x2.fill"
         )
         
         tabBarItem.tag = 0
         navigationController.tabBarItem = tabBarItem
         
-        let homeRouter = NavigationRouter(navigationController: navigationController)
-        let homeCoordinator = HomeCoordinator(router: homeRouter)
-        viewController.delegate = homeCoordinator
+        let widgetsRouter = NavigationRouter(navigationController: navigationController)
+        let widgetsCoordinator = HomeCoordinator(router: widgetsRouter)
+        viewController.delegate = widgetsCoordinator
         
-        children.append(homeCoordinator)
+        children.append(widgetsCoordinator)
         return navigationController
     }
     

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -566,7 +566,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Home"
+            "value" : "Widgets"
           }
         }
       }

--- a/Modulite/Screens/RootTabBarController.swift
+++ b/Modulite/Screens/RootTabBarController.swift
@@ -136,11 +136,13 @@ extension RootTabBarController: UITabBarControllerDelegate {
 
     override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
         tabBar.standardAppearance.stackedLayoutAppearance.selected.titleTextAttributes = [
-            .foregroundColor: self.getColorForSelectedTag()
+            .foregroundColor: self.getColorForSelectedTag(),
+            .font: UIFont(textStyle: .footnote, weight: .bold)
         ]
         
         tabBar.scrollEdgeAppearance?.stackedLayoutAppearance.selected.titleTextAttributes = [
-            .foregroundColor: self.getColorForSelectedTag()
+            .foregroundColor: self.getColorForSelectedTag(),
+            .font: UIFont(textStyle: .footnote, weight: .bold)
         ]
         
         DispatchQueue.main.async { [weak self] in


### PR DESCRIPTION
## Issue Reference
This PR closes #189, changing the icon and name from Home to Widgets, following Danilo's feedback and also now when a page is selected its name is in bold

## Summary
1. **Changed** from **“Home” to “Widgets”** in the `TabBar`, also updating the icon to one that more closely matches the widget context 

2. The text in **for the names of the selected pages** is now displayed in **bold**.
