### PR TITLE
Fixed Missing Texts in `WidgetEditorView`

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
@@ -225,7 +225,6 @@ class WidgetEditorView: UIScrollView {
         contentView.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(UIEdgeInsets(top: 24, left: 24, bottom: 24, right: -24))
             make.width.equalToSuperview().offset(-48)
-            make.height.equalTo(900)
         }
         
         layoutHeader.snp.makeConstraints { make in


### PR DESCRIPTION
## Issue Reference

This PR closes #200, fixing a bug where texts were disappearing from `WidgetEditorView`.

## Summary

1. **Fixed Height Constraint Issue**: Resolved a bug that caused texts to disappear from the `WidgetEditorView`. The issue was due to a height constraint that was incorrectly limiting the view, causing the text content to be clipped and not displayed correctly.

2. **Constraint Adjustment**: Updated the height constraint to properly accommodate all content in the `WidgetEditorView`, ensuring that texts are always fully visible regardless of the content size.

## Testing

- Verified that all text elements in `WidgetEditorView` are visible and no longer disappear due to constraint issues.
- Tested the view with different content sizes to ensure that the layout adjusts dynamically without clipping text.
- Confirmed that the UI remains consistent in both light and dark modes.