### PR TITLE
Customized Info Buttons in `WidgetEditorView`

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Editor/View/EditorSectionHeader.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/EditorSectionHeader.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 class EditorSectionHeader: UIView {
     
@@ -24,11 +25,28 @@ class EditorSectionHeader: UIView {
     }()
     
     private(set) lazy var infoButton: UIButton = {
-        let view = UIButton()
-        // TODO: Fix image sizing
-        view.setImage(UIImage(systemName: "info.circle")!, for: .normal)
-            
+        var config = UIButton.Configuration.plain()
+        
+        config.baseForegroundColor = .carrotOrange
+        config.image = UIImage(systemName: "info.circle")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 17, weight: .semibold)
+        )
+        
+        config.contentInsets = .zero
+        
+        let view = UIButton(configuration: config)
         view.addTarget(self, action: #selector(infoButtonTapped), for: .touchUpInside)
+        
+        view.configurationUpdateHandler = { button in
+            UIView.animate(withDuration: 0.15) {
+                switch button.state {
+                case .highlighted:
+                    button.alpha = 0.6
+                default:
+                    button.alpha = 1
+                }
+            }
+        }
         
         return view
     }()

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
@@ -225,6 +225,7 @@ class WidgetEditorView: UIScrollView {
         contentView.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(UIEdgeInsets(top: 24, left: 24, bottom: 24, right: -24))
             make.width.equalToSuperview().offset(-48)
+            make.height.greaterThanOrEqualTo(900)
         }
         
         layoutHeader.snp.makeConstraints { make in


### PR DESCRIPTION
## Issue Reference

This PR closes #199, customizing the `infoButton` in the view to enhance its appearance and interaction.

## Summary

1. **Customized `infoButton` Styling**: Updated the `infoButton` to use a new configuration style that improves its visual appearance. The button is now styled with a carrot orange color and uses a more suitable image size and weight.

2. **Updated Button Configuration**:
   - **Button Image**: Changed the button image to use `UIImage(systemName: "info.circle")` with a custom configuration that sets the point size to **17** and weight to **semibold**, ensuring the icon is more prominent and fits well with the overall design.
   - **Button Style**: Switched to using a **UIButton.Configuration** of type `.plain()`, allowing for more flexibility in customizing button appearance.

3. **Highlight Animation**: Added an animation effect to the `infoButton` when it is pressed, changing the button's alpha to **0.6** for a highlighted state and animating back to **1** for the normal state. This subtle animation enhances the user experience by providing visual feedback when interacting with the button.

## Testing

- Verified that the `infoButton` displays correctly with the updated styling and image size.
- Tested the highlight animation to ensure that it triggers properly when the button is pressed.
- Confirmed that the button interaction remains consistent and responsive across different parts of the app.