### PR TITLE
Fixed Free Badge To Light Mode Colors

### DIFF
--- a/Modulite/Components/ModulitePlus/ModuliteFreeSmallBadge.swift
+++ b/Modulite/Components/ModulitePlus/ModuliteFreeSmallBadge.swift
@@ -11,7 +11,14 @@ class ModuliteFreeSmallBadge: GradientLabelView {
     convenience init() {
         self.init(
             gradient: Gradient(
-                colors: [.potatoYellow, .potatoYellow],
+                colors: [
+                    .potatoYellow.resolvedColor(
+                        with: .init(userInterfaceStyle: .light)
+                    ),
+                    .potatoYellow.resolvedColor(
+                        with: .init(userInterfaceStyle: .light)
+                    )
+                ],
                 direction: CGVector(dx: 1, dy: 0)
             ),
             insets: .init(vertical: 5, horizontal: 5)


### PR DESCRIPTION
## Issue Reference

This PR closes #204, ensuring that the gradient color in `ModuliteFreeSmallBadge` always uses the light mode version of `potatoYellow`.

## Summary

1. **Gradient Color Adjustment**: Modified the gradient in `ModuliteFreeSmallBadge` to always use the **light mode version** of `potatoYellow`. This change was made to maintain visual consistency regardless of the system's current appearance settings, ensuring that the badge retains a recognizable and consistent look.

2. **Override Dark Mode**: Explicitly set the color so that even when the app is in dark mode, the badge still displays the `potatoYellow` light version. This provides a more cohesive user experience, where specific elements remain unchanged by the system theme.

## Testing

- Verified that `ModuliteFreeSmallBadge` consistently displays the light mode version of `potatoYellow`, regardless of whether the app is in light or dark mode.