### PR TITLE
Implemented Customized Wallpaper Download Alert Messages

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		B33808B02CC47C0300D56884 /* RequestScreenTimeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33808AF2CC47C0300D56884 /* RequestScreenTimeCoordinator.swift */; };
 		B33808B22CC6D83300D56884 /* UsageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33808B12CC6D83300D56884 /* UsageView.swift */; };
 		B33808B82CC7070800D56884 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33808B62CC7070800D56884 /* LoadingView.swift */; };
+		B34C62D62CCC1585004E014B /* WallpaperSaveError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34C62D42CCC1585004E014B /* WallpaperSaveError.swift */; };
+		B34C62D82CCC18D8004E014B /* WidgetEditorLocalizedTexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34C62D72CCC18D8004E014B /* WidgetEditorLocalizedTexts.swift */; };
 		B34F3DF02C66EACE0041D7BD /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = B34F3DEF2C66EACE0041D7BD /* SnapKit */; };
 		B34F3DF32C6701740041D7BD /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B34F3DF22C6701740041D7BD /* Localizable.xcstrings */; };
 		B34F3DF52C6701870041D7BD /* String+LocalizedKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34F3DF42C6701870041D7BD /* String+LocalizedKey.swift */; };
@@ -456,6 +458,8 @@
 		B33808AF2CC47C0300D56884 /* RequestScreenTimeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestScreenTimeCoordinator.swift; sourceTree = "<group>"; };
 		B33808B12CC6D83300D56884 /* UsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageView.swift; sourceTree = "<group>"; };
 		B33808B62CC7070800D56884 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		B34C62D42CCC1585004E014B /* WallpaperSaveError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperSaveError.swift; sourceTree = "<group>"; };
+		B34C62D72CCC18D8004E014B /* WidgetEditorLocalizedTexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEditorLocalizedTexts.swift; sourceTree = "<group>"; };
 		B34F3DF22C6701740041D7BD /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		B34F3DF42C6701870041D7BD /* String+LocalizedKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+LocalizedKey.swift"; sourceTree = "<group>"; };
 		B34F3DF72C69A3810041D7BD /* DebugOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOptions.swift; sourceTree = "<group>"; };
@@ -981,6 +985,14 @@
 			path = Loading;
 			sourceTree = "<group>";
 		};
+		B34C62D52CCC1585004E014B /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				B34C62D42CCC1585004E014B /* WallpaperSaveError.swift */,
+			);
+			path = Errors;
+			sourceTree = "<group>";
+		};
 		B34F3DF12C6701070041D7BD /* Localization */ = {
 			isa = PBXGroup;
 			children = (
@@ -1091,6 +1103,7 @@
 				B350C04F2C8B90860035682F /* View */,
 				B350C04E2C8B907B0035682F /* ViewController */,
 				B350C04D2C8B90750035682F /* ViewModel */,
+				B34C62D72CCC18D8004E014B /* WidgetEditorLocalizedTexts.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -1098,6 +1111,7 @@
 		B350C04D2C8B90750035682F /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				B34C62D52CCC1585004E014B /* Errors */,
 				B34F3E392C74BFB00041D7BD /* WidgetEditorViewModel.swift */,
 			);
 			path = ViewModel;
@@ -2586,10 +2600,12 @@
 				B34F3E402C74E3270041D7BD /* WidgetModuleCell.swift in Sources */,
 				B33808AC2CC31D8300D56884 /* RequestScreenTimeTexts.swift in Sources */,
 				B35BFB892CB4605C00092B42 /* TutorialMultiParagraphLabel.swift in Sources */,
+				B34C62D62CCC1585004E014B /* WallpaperSaveError.swift in Sources */,
 				B35BFB8A2CB4605C00092B42 /* TutorialTextParagraphLabel.swift in Sources */,
 				B35BFBE72CB5AAA600092B42 /* TutorialCenterLocalizedTexts.swift in Sources */,
 				B35BFB8B2CB4605C00092B42 /* TutorialTitleLabel.swift in Sources */,
 				B34F3E1C2C6BD3DA0041D7BD /* HomeViewModel.swift in Sources */,
+				B34C62D82CCC18D8004E014B /* WidgetEditorLocalizedTexts.swift in Sources */,
 				B32B61012C88EC1A007DDCE3 /* WidgetSetupStyleCompositionalLayout.swift in Sources */,
 				B3D1B7CD2CB6FC5400DFC4F5 /* FAQViewModel.swift in Sources */,
 				B39D89DB2CB85B8C005EEC46 /* ComingSoonFeature.swift in Sources */,

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -486,6 +486,17 @@
         }
       }
     },
+    "gotIt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got it!"
+          }
+        }
+      }
+    },
     "guest" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -849,6 +860,17 @@
         }
       }
     },
+    "photosAuthorizationDenied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permission to access the photo library was denied. Please enable access in Settings."
+          }
+        }
+      }
+    },
     "plus" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -961,6 +983,17 @@
     },
     "Save" : {
 
+    },
+    "saveFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to save the wallpaper: %@"
+          }
+        }
+      }
     },
     "Select Apps" : {
 
@@ -1900,6 +1933,28 @@
         }
       }
     },
+    "unableToSaveWallpaper" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to prepare the wallpaper for saving."
+          }
+        }
+      }
+    },
+    "unknownErrorOcurred" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An unknown error ocurred. Please try again."
+          }
+        }
+      }
+    },
     "usageDailyAvarageLastWeek" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1984,6 +2039,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "You have spent"
+          }
+        }
+      }
+    },
+    "wallpaperUnknownError" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An unknown error occurred while saving the wallpaper."
           }
         }
       }
@@ -2141,6 +2207,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Download your matching wallpaper"
+          }
+        }
+      }
+    },
+    "widgetEditorWallpaperAlertErrorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An Error Ocurred"
+          }
+        }
+      }
+    },
+    "widgetEditorWallpaperAlertSuccessMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can set it on Settings > Wallpaper > Add new Wallpaper"
+          }
+        }
+      }
+    },
+    "widgetEditorWallpaperAlertSuccessTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallpapers were successfully downloaded!"
           }
         }
       }

--- a/Modulite/Localization/String+LocalizedKey.swift
+++ b/Modulite/Localization/String+LocalizedKey.swift
@@ -142,6 +142,8 @@ extension String {
         case plus
         case free
         case guest
+        case gotIt
+        case unknownErrorOcurred
         case comingSoonTitle
         case comingSoonMessageSingular(feature: String)
         case comingSoonMessagePlural(feature: String)

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/Errors/WallpaperSaveError.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/Errors/WallpaperSaveError.swift
@@ -6,3 +6,14 @@
 //
 
 import Foundation
+
+enum WallpaperSaveError: LocalizedError, LocalizedKeyProtocol {
+    case unableToSaveWallpaper
+    case photosAuthorizationDenied
+    case saveFailed(Error)
+    case wallpaperUnknownError
+    
+    var errorDescription: String? {
+        .localized(for: self)
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/Errors/WallpaperSaveError.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/Errors/WallpaperSaveError.swift
@@ -1,0 +1,8 @@
+//
+//  WallpaperSaveError.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 25/10/24.
+//
+
+import Foundation

--- a/Modulite/Screens/WidgetConfiguration/Editor/WidgetEditorLocalizedTexts.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/WidgetEditorLocalizedTexts.swift
@@ -6,3 +6,10 @@
 //
 
 import Foundation
+
+enum WidgetEditorLocalizedTexts: LocalizedKeyProtocol {
+    case widgetEditorWallpaperAlertSuccessTitle
+    case widgetEditorWallpaperAlertSuccessMessage
+    
+    case widgetEditorWallpaperAlertErrorTitle
+}

--- a/Modulite/Screens/WidgetConfiguration/Editor/WidgetEditorLocalizedTexts.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/WidgetEditorLocalizedTexts.swift
@@ -1,0 +1,8 @@
+//
+//  WidgetEditorLocalizedTexts.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 25/10/24.
+//
+
+import Foundation


### PR DESCRIPTION
## Issue Reference

This PR closes #206, adding customized messages to the alert for saving wallpapers in `WidgetEditorView`.

## Summary

1. **Improved Wallpaper Save Logic**:
   - Refactored the wallpaper save flow to use a completion handler, providing better error handling and a more robust save process. This includes handling success, failure, and permission-related issues.

2. **Custom Alert Messages**:
   - Implemented custom messages for the alert displayed when attempting to save a wallpaper.
   - The alert now differentiates between different outcomes:
     - **Success Message**: Displays a success message when the wallpaper is saved successfully.
     - **Permission Denied**: Displays a specific error message if saving fails due to missing photo library permissions.
     - **General Error**: Displays an appropriate error message if there is an unexpected failure during the save process.

3. **User Feedback Enhancement**:
   - Added user-friendly messages based on the specific error encountered to ensure users are clearly informed about what went wrong or whether the save was successful.
   - The button labels and messages are fully localized for a consistent user experience.

## Testing

- Verified that the alert shows the correct message for each type of result:
  - Success in saving to the photo library.
  - Failure due to lack of permissions.
  - General errors during the save process.
- Tested the alert functionality under both authorized and unauthorized photo library settings to ensure proper error handling.
- Confirmed that the alerts are correctly localized.