### PR TITLE
Changed Download Wallpaper Button Image Color to `.white`

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDownloadButton.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDownloadButton.swift
@@ -38,7 +38,7 @@ class WidgetEditorDownloadButton: UIButton {
         config.titleLineBreakMode = .byClipping
         
         config.image = UIImage(systemName: "square.and.arrow.down")?
-            .withTintColor(.textPrimary, renderingMode: .alwaysOriginal)
+            .withTintColor(.white, renderingMode: .alwaysOriginal)
             .withConfiguration(
                 UIImage.SymbolConfiguration(
                     font: UIFont(textStyle: .body, weight: .semibold)


### PR DESCRIPTION
## Issue Reference

This PR closes #225 by changing the color of the download button image.

## Summary

- Updated the download button image color from `textPrimary` to `white`, providing better contrast and visibility across different backgrounds.

## Testing

- Verified that the button image appears correctly with the updated color in various parts of the UI.
- Ensured that the new color improves the button's visibility and provides a consistent user experience.