### PR TITLE
Removed `Phone` and `Facetime` URL Schemes

### DIFF
--- a/Modulite/Resources/apps.json
+++ b/Modulite/Resources/apps.json
@@ -2,8 +2,7 @@
     "version": 1,
     "apps": [
         {"name": "Mail", "urlScheme": "message://", "relevance": 1},
-        {"name": "Messages", "urlScheme": "sms://phonenumber", "relevance": 1},
-        {"name": "Phone", "urlScheme": "tel://phonenumber", "relevance": 1},
+        {"name": "Messages", "urlScheme": "messages://", "relevance": 1},
         {"name": "WhatsApp", "urlScheme": "whatsapp://", "relevance": 1},
         {"name": "Safari", "urlScheme": "x-web-search://", "relevance": 1},
         {"name": "Google Maps", "urlScheme": "googlemaps://", "relevance": 1},
@@ -23,7 +22,6 @@
 
         {"name": "Apple Music", "urlScheme": "music://", "relevance": 3},
         {"name": "Contacts", "urlScheme": "contacts://", "relevance": 3},
-        {"name": "FaceTime", "urlScheme": "facetime://phoneoremail", "relevance": 3},
         {"name": "Files", "urlScheme": "shareddocuments://", "relevance": 3},
         {"name": "Shortcuts", "urlScheme": "shortcuts://", "relevance": 3},
         {"name": "Wallet", "urlScheme": "shoebox://", "relevance": 3},


### PR DESCRIPTION
## Issue Reference

This PR closes #227 by adjusting URL schemes to improve their behavior.

## Summary

1. **Removed Phone and FaceTime URL Schemes**:
   - Removed the URL schemes for `phone` and `facetime` as they require specific parameters to function properly, which could lead to inconsistent behavior if those parameters are missing.

2. **Updated SMS URL Scheme**:
   - Changed the URL scheme from `sms` to `messages`, which now simply opens the Messages app instead of starting a new message draft automatically. This provides a more intuitive experience for users who may not want to initiate a new message.

## Testing

- Verified that the app no longer attempts to use `phone` or `facetime` URL schemes.
- Confirmed that clicking on the updated `messages` URL scheme correctly opens the Messages app without unexpected behavior.