### PR TITLE
Refactored Buttons To Use `ButtonFactory`

### DIFF
--- a/Modulite/Factories/Views/ButtonFactory.swift
+++ b/Modulite/Factories/Views/ButtonFactory.swift
@@ -34,7 +34,7 @@ enum ButtonFactory {
             
             config.attributedTitle = attributedTitle
         }
-
+        
         let image = image?
             .withTintColor(foregroundColor, renderingMode: .alwaysOriginal)
             .withConfiguration(
@@ -80,52 +80,38 @@ enum ButtonFactory {
         contentHorizontalAlignment: UIControl.ContentHorizontalAlignment = .center,
         size: CGSize = CGSize(width: 230, height: 45)
     ) -> UIButton {
-        var config = UIButton.Configuration.filled()
+        let config = mediumButtonConfiguration(
+            titleKey: titleKey,
+            font: font,
+            image: image,
+            imagePadding: imagePadding,
+            imagePlacement: imagePlacement,
+            imagePointSize: imagePointSize,
+            foregroundColor: foregroundColor,
+            backgroundColor: backgroundColor,
+            contentHorizontalAlignment: contentHorizontalAlignment
+        )
         
-        if let titleKey {
-            let attributedTitle = AttributedString(
-                .localized(for: titleKey),
-                attributes: AttributeContainer([
-                    .font: font,
-                    .foregroundColor: foregroundColor
-                ])
-            )
-            
-            config.attributedTitle = attributedTitle
-        }
-
-        let image = image?
-            .withTintColor(foregroundColor, renderingMode: .alwaysOriginal)
-            .withConfiguration(
-                UIImage.SymbolConfiguration(pointSize: imagePointSize, weight: .semibold)
-            )
+        let button = UIButton(configuration: config)
         
-        config.image = image
-        config.imagePadding = imagePadding
-        config.imagePlacement = imagePlacement
-        config.baseForegroundColor = foregroundColor
-        config.baseBackgroundColor = backgroundColor
-        
-        let view = UIButton(configuration: config)
-        
-        view.snp.makeConstraints { make in
-            make.width.height.equalTo(size)
+        button.snp.makeConstraints { make in
+            make.width.equalTo(size.width)
+            make.height.equalTo(size.height)
         }
         
-        view.configurationUpdateHandler = { button in
+        button.configurationUpdateHandler = { button in
             UIView.animate(withDuration: 0.1) {
-                switch button.state {
-                case .highlighted:
-                    button.transform = .init(scaleX: 0.97, y: 0.97)
-                default:
+                if button.state == .highlighted {
+                    button.transform = CGAffineTransform(scaleX: 0.97, y: 0.97)
+                } else {
                     button.transform = .identity
                 }
             }
         }
         
-        view.contentHorizontalAlignment = contentHorizontalAlignment
+        button.contentHorizontalAlignment = contentHorizontalAlignment
         
-        return view
+        return button
     }
     
     static func textLinkButton(
@@ -147,14 +133,14 @@ enum ButtonFactory {
         chevronAttachment.image = UIImage(systemName: "chevron.right")?
             .withTintColor(color, renderingMode: .alwaysOriginal)
             .withConfiguration(UIImage.SymbolConfiguration(weight: .bold))
-                
+        
         chevronAttachment.bounds = CGRect(
             x: 0,
             y: (UIFont.preferredFont(forTextStyle: textStyle).descender + 2),
             width: 11,
             height: 14
         )
-    
+        
         let chevronString = NSAttributedString(attachment: chevronAttachment)
         attributedText.append(NSAttributedString(string: " "))
         attributedText.append(chevronString)
@@ -183,5 +169,47 @@ enum ButtonFactory {
         }
         
         return button
+    }
+}
+
+extension ButtonFactory {
+    static func mediumButtonConfiguration(
+        titleKey: LocalizedKeyProtocol? = nil,
+        font: UIFont = .spaceGrotesk(forTextStyle: .title3, weight: .bold),
+        image: UIImage? = nil,
+        imagePadding: CGFloat = 10,
+        imagePlacement: NSDirectionalRectEdge = .leading,
+        imagePointSize: CGFloat = 17,
+        foregroundColor: UIColor = .white,
+        backgroundColor: UIColor = .fiestaGreen,
+        contentHorizontalAlignment: UIControl.ContentHorizontalAlignment = .center
+    ) -> UIButton.Configuration {
+        var config = UIButton.Configuration.filled()
+        
+        if let titleKey {
+            let attributedTitle = AttributedString(
+                .localized(for: titleKey),
+                attributes: AttributeContainer([
+                    .font: font,
+                    .foregroundColor: foregroundColor
+                ])
+            )
+            config.attributedTitle = attributedTitle
+        }
+        
+        let image = image?
+            .withTintColor(foregroundColor, renderingMode: .alwaysOriginal)
+            .withConfiguration(
+                UIImage.SymbolConfiguration(pointSize: imagePointSize, weight: .semibold)
+            )
+        
+        config.image = image
+        config.imagePadding = imagePadding
+        config.imagePlacement = imagePlacement
+        config.baseForegroundColor = foregroundColor
+        config.baseBackgroundColor = backgroundColor
+        config.contentInsets = .zero
+        
+        return config
     }
 }

--- a/Modulite/Factories/Views/ButtonFactory.swift
+++ b/Modulite/Factories/Views/ButtonFactory.swift
@@ -11,11 +11,11 @@ import SnapKit
 enum ButtonFactory {
     static func smallButton(
         titleKey: LocalizedKeyProtocol? = nil,
-        font: UIFont = UIFont(textStyle: .title3, weight: .bold),
+        font: UIFont = .spaceGrotesk(forTextStyle: .title3, weight: .bold),
         image: UIImage? = nil,
         imagePadding: CGFloat = 10,
         imagePlacement: NSDirectionalRectEdge = .trailing,
-        imagePointSize: CGFloat = 20,
+        imagePointSize: CGFloat = 17,
         foregroundColor: UIColor = .white,
         backgroundColor: UIColor = .blueberry,
         contentHorizontalAlignment: UIControl.ContentHorizontalAlignment = .center,
@@ -70,11 +70,11 @@ enum ButtonFactory {
     
     static func mediumButton(
         titleKey: LocalizedKeyProtocol? = nil,
-        font: UIFont = UIFont(textStyle: .title3, weight: .bold),
+        font: UIFont = .spaceGrotesk(forTextStyle: .title3, weight: .bold),
         image: UIImage? = nil,
         imagePadding: CGFloat = 10,
         imagePlacement: NSDirectionalRectEdge = .leading,
-        imagePointSize: CGFloat = 20,
+        imagePointSize: CGFloat = 17,
         foregroundColor: UIColor = .white,
         backgroundColor: UIColor = .fiestaGreen,
         contentHorizontalAlignment: UIControl.ContentHorizontalAlignment = .center,

--- a/Modulite/Localization/Localizable.xcstrings
+++ b/Modulite/Localization/Localizable.xcstrings
@@ -2618,6 +2618,17 @@
         }
       }
     },
+    "widgetEditorDeleteButtonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DELETE"
+          }
+        }
+      }
+    },
     "widgetEditorViewDeleteAlertMessage" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modulite/Screens/Onboarding/Welcome/View/WelcomeView.swift
+++ b/Modulite/Screens/Onboarding/Welcome/View/WelcomeView.swift
@@ -44,23 +44,12 @@ class WelcomeView: UIView {
     }()
     
     private(set) lazy var startButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        config.baseForegroundColor = .white
-        config.baseBackgroundColor = .fiestaGreen
-        config.image = UIImage(systemName: "arrow.right")?
-            .withTintColor(.white, renderingMode: .alwaysOriginal)
-            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 16, weight: .bold))
-        
-        config.imagePlacement = .trailing
-        config.imagePadding = 12
-        config.attributedTitle = AttributedString(
-            .localized(for: OnboardingLocalizedTexts.onboardingGetStartedButton),
-            attributes: AttributeContainer([
-                .font: UIFont(textStyle: .title2, weight: .bold)
-            ])
+        let view = ButtonFactory.mediumButton(
+            titleKey: OnboardingLocalizedTexts.onboardingGetStartedButton,
+            image: UIImage(systemName: "arrow.right"),
+            imagePlacement: .trailing
         )
         
-        let view = UIButton(configuration: config)
         view.addTarget(self, action: #selector(startButtonTapped), for: .touchUpInside)
         
         return view

--- a/Modulite/Screens/RequestScreenTime/View/RequestScreenTimeView.swift
+++ b/Modulite/Screens/RequestScreenTime/View/RequestScreenTimeView.swift
@@ -103,22 +103,15 @@ class RequestScreenTimeView: UIView {
     }()
     
     private(set) lazy var connectButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        config.baseForegroundColor = .white
-        config.baseBackgroundColor = .fiestaGreen.resolvedColor(
-            with: .init(userInterfaceStyle: .light)
-        )
-        config.attributedTitle = AttributedString(
-            .localized(for: RequestScreenTimeTexts.requestScreenConnectButtonTitle),
-            attributes: AttributeContainer([
-                .font: UIFont(textStyle: .title2, weight: .bold)
-            ])
+        let button = ButtonFactory.mediumButton(
+            titleKey: RequestScreenTimeTexts.requestScreenConnectButtonTitle,
+            font: .spaceGrotesk(forTextStyle: .title2, weight: .bold),
+            backgroundColor: .fiestaGreen.resolvedColor(with: .init(userInterfaceStyle: .light))
         )
         
-        let view = UIButton(configuration: config)
-        view.addTarget(self, action: #selector(didPressConnectButton), for: .touchUpInside)
+        button.addTarget(self, action: #selector(didPressConnectButton), for: .touchUpInside)
         
-        return view
+        return button
     }()
     
     private(set) lazy var dismissButton: UIButton = {
@@ -212,7 +205,7 @@ class RequestScreenTimeView: UIView {
             make.left.right.equalToSuperview().inset(24)
         }
         
-        connectButton.snp.makeConstraints { make in
+        connectButton.snp.remakeConstraints { make in
             make.top.equalTo(footnoteLabel.snp.bottom).offset(32)
             make.left.right.equalToSuperview().inset(24)
             make.height.equalTo(44)

--- a/Modulite/Screens/SettingsTab/Help/View/HelpView.swift
+++ b/Modulite/Screens/SettingsTab/Help/View/HelpView.swift
@@ -20,32 +20,16 @@ class HelpView: UIScrollView {
     private(set) var topicsStackView = HelpTopicsStackView()
     
     private(set) lazy var reportIssuesButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        
-        config.attributedTitle = AttributedString(
-            .localized(for: HelpLocalizedTexts.helpViewEncounteredBugButton),
-            attributes: AttributeContainer([
-                .font: UIFont(textStyle: .title2, weight: .bold)
-            ])
+        let button = ButtonFactory.mediumButton(
+            titleKey: HelpLocalizedTexts.helpViewEncounteredBugButton,
+            font: .spaceGrotesk(forTextStyle: .title2, weight: .bold),
+            image: UIImage(systemName: "envelope"),
+            backgroundColor: .blueberry
         )
+
+        button.addTarget(self, action: #selector(reportIssuesButtonTapped), for: .touchUpInside)
         
-        config.baseBackgroundColor = .blueberry
-        config.baseForegroundColor = .white
-        
-        let envelopeIcon = UIImage(systemName: "envelope")?
-            .withTintColor(.white, renderingMode: .alwaysOriginal)
-            .withConfiguration(
-                UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
-            )
-        
-        config.image = envelopeIcon
-        config.imagePlacement = .leading
-        config.imagePadding = 5
-         
-        let view = UIButton(configuration: config)
-        view.addTarget(self, action: #selector(reportIssuesButtonTapped), for: .touchUpInside)
-        
-        return view
+        return button
     }()
     
     private(set) var moduliteTeamLabel: UILabel = {
@@ -103,8 +87,6 @@ class HelpView: UIScrollView {
         
         reportIssuesButton.snp.makeConstraints { make in
             make.top.equalTo(topicsStackView.snp.bottom).offset(16)
-            make.height.equalTo(45)
-            make.width.greaterThanOrEqualTo(230)
             make.centerX.equalToSuperview()
         }
         

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDeleteButton.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDeleteButton.swift
@@ -24,24 +24,23 @@ class WidgetEditorDeleteButton: UIButton {
     // MARK: - Setup
     
     private func setupButton() {
-        var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = .ketchupRed
         
-        config.attributedTitle = AttributedString(
-            .localized(for: .delete).uppercased(),
-            attributes: AttributeContainer([
-                .font: UIFont(textStyle: .body, weight: .bold),
-                .foregroundColor: UIColor.white
-            ])
+        let config = ButtonFactory.mediumButtonConfiguration(
+            titleKey: WidgetEditorLocalizedTexts.widgetEditorDeleteButtonTitle,
+            image: UIImage(systemName: "trash"),
+            backgroundColor: .ketchupRed
         )
-        
-        config.imagePlacement = .leading
-        config.image = UIImage(systemName: "trash")
-        config.imagePadding = 10
-        config.preferredSymbolConfigurationForImage = .init(pointSize: 15, weight: .bold)
-        config.baseForegroundColor = .white
+    
+        self.configurationUpdateHandler = { button in
+            UIView.animate(withDuration: 0.1) {
+                if button.state == .highlighted {
+                    button.transform = CGAffineTransform(scaleX: 0.97, y: 0.97)
+                } else {
+                    button.transform = .identity
+                }
+            }
+        }
         
         configuration = config
-        layer.cornerRadius = 0
     }
 }

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDownloadButton.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorDownloadButton.swift
@@ -24,32 +24,14 @@ class WidgetEditorDownloadButton: UIButton {
     // MARK: - Setup
     
     private func setupButton() {
-        var config = UIButton.Configuration.bordered()
-        
-        config.attributedTitle = AttributedString(
-            .localized(for: .widgetEditorViewWallpaperButton),
-            attributes: AttributeContainer([
-                .font: UIFont(textStyle: .body, weight: .bold),
-                .foregroundColor: UIColor.white
-            ])
+        var config = ButtonFactory.mediumButtonConfiguration(
+            titleKey: String.LocalizedKey.widgetEditorViewWallpaperButton,
+            image: UIImage(systemName: "square.and.arrow.down"),
+            backgroundColor: .carrotOrange
         )
         
-        config.titleAlignment = .center
         config.titleLineBreakMode = .byClipping
-        
-        config.image = UIImage(systemName: "square.and.arrow.down")?
-            .withTintColor(.white, renderingMode: .alwaysOriginal)
-            .withConfiguration(
-                UIImage.SymbolConfiguration(
-                    font: UIFont(textStyle: .body, weight: .semibold)
-                )
-            )
-        
-        config.imagePlacement = .leading
-        config.imagePadding = 5
-        
-        config.baseBackgroundColor = .carrotOrange
-        
+        config.contentInsets = .init(top: 8, leading: 8, bottom: 10, trailing: 10)
         configuration = config
         
         configurationUpdateHandler = { button in
@@ -58,17 +40,17 @@ class WidgetEditorDownloadButton: UIButton {
             UIView.animate(withDuration: 0.1) {
                 switch button.state {
                 case .highlighted:
-                    button.alpha = 0.67
+                    button.alpha = 0.9
                     button.transform = CGAffineTransform(scaleX: 0.97, y: 0.97)
                     
                 case .disabled:
-                    button.alpha = 0.67
-                    button.layer.borderColor = UIColor.gray.cgColor
+                    button.alpha = 0.9
+                    updatedConfig?.background.backgroundColor = .systemGray2
                     updatedConfig?.attributedTitle = AttributedString(
                         .localized(for: .widgetEditorViewWallpaperButtonSaved),
                         attributes: AttributeContainer([
-                            .font: UIFont(textStyle: .body, weight: .bold),
-                            .foregroundColor: UIColor.textPrimary
+                            .font: UIFont.spaceGrotesk(forTextStyle: .title3, weight: .bold),
+                            .foregroundColor: UIColor.white
                         ])
                     )
                     button.configuration = updatedConfig

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorSaveButton.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/Subviews/WidgetEditorSaveButton.swift
@@ -24,35 +24,41 @@ class WidgetEditorSaveButton: UIButton {
     // MARK: - Setup
     
     private func setupButton() {
-        var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = .fiestaGreen
-        
-        config.attributedTitle = AttributedString(
-            .localized(for: .widgetEditorViewSaveWidgetButton),
-            attributes: AttributeContainer([
-                .font: UIFont(textStyle: .body, weight: .bold),
-                .foregroundColor: UIColor.white
-            ])
+        self.configuration = ButtonFactory.mediumButtonConfiguration(
+            titleKey: String.LocalizedKey.widgetEditorViewSaveWidgetButton,
+            font: UIFont.spaceGrotesk(forTextStyle: .body, weight: .bold),
+            image: UIImage(systemName: "checkmark"),
+            imagePadding: 10,
+            imagePlacement: .leading,
+            imagePointSize: 15,
+            foregroundColor: .white,
+            backgroundColor: .fiestaGreen,
+            contentHorizontalAlignment: .center
         )
-        
-        config.imagePlacement = .leading
-        config.image = UIImage(systemName: "checkmark")
-        config.imagePadding = 10
-        config.preferredSymbolConfigurationForImage = .init(pointSize: 15, weight: .bold)
-        config.baseForegroundColor = .white
-        
-        self.configuration = config
+                
         self.layer.cornerRadius = 0
+                
+        self.configurationUpdateHandler = { button in
+            UIView.animate(withDuration: 0.1) {
+                if button.state == .highlighted {
+                    button.transform = CGAffineTransform(scaleX: 0.97, y: 0.97)
+                } else {
+                    button.transform = .identity
+                }
+            }
+        }
+                
+        self.contentHorizontalAlignment = .center
     }
     
-    // MARK: - Appereance updating
+    // MARK: - Appearance Updating
     
     func setToEditingState() {
         var config = self.configuration
         config?.attributedTitle = AttributedString(
             .localized(for: .save).uppercased(),
             attributes: AttributeContainer([
-                .font: UIFont(textStyle: .body, weight: .bold),
+                .font: UIFont.spaceGrotesk(forTextStyle: .title3, weight: .bold),
                 .foregroundColor: UIColor.white
             ])
         )

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
@@ -159,7 +159,9 @@ class WidgetEditorView: UIScrollView {
             make.width.equalTo(130)
             make.right.equalToSuperview().inset(24)
         }
-            
+        
+        deleteWidgetButton.snp.removeConstraints()
+        
         deleteWidgetButton.snp.makeConstraints { make in
             make.top.width.height.equalTo(saveWidgetButton)
             make.left.equalToSuperview().inset(24)
@@ -225,7 +227,7 @@ class WidgetEditorView: UIScrollView {
         contentView.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(UIEdgeInsets(top: 24, left: 24, bottom: 24, right: -24))
             make.width.equalToSuperview().offset(-48)
-            make.height.greaterThanOrEqualTo(900)
+            make.height.greaterThanOrEqualTo(950)
         }
         
         layoutHeader.snp.makeConstraints { make in
@@ -266,8 +268,6 @@ class WidgetEditorView: UIScrollView {
         
         downloadWallpaperButton.snp.makeConstraints { make in
             make.top.equalTo(wallpaperHeader.snp.bottom).offset(16)
-//            make.width.greaterThanOrEqualTo(260)
-            make.height.equalTo(40)
             make.centerX.equalToSuperview()
         }
         

--- a/Modulite/Screens/WidgetConfiguration/Editor/WidgetEditorLocalizedTexts.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/WidgetEditorLocalizedTexts.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 enum WidgetEditorLocalizedTexts: LocalizedKeyProtocol {
+    case widgetEditorDeleteButtonTitle
+    
     case widgetEditorWallpaperAlertSuccessTitle
     case widgetEditorWallpaperAlertSuccessMessage
     

--- a/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
@@ -65,13 +65,7 @@ class WidgetSetupView: UIScrollView {
             imagePointSize: 17,
             backgroundColor: .carrotOrange
         )
-        var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = .carrotOrange
-        config.title = .localized(for: .widgetSetupViewSearchAppsButtonTitle)
-        config.image = UIImage(systemName: "magnifyingglass")
-        config.imagePadding = 10
-        
-        let view = UIButton(configuration: config)
+                
         button.addTarget(self, action: #selector(handleSearchButtonPressed), for: .touchUpInside)
         
         return button

--- a/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
@@ -59,6 +59,12 @@ class WidgetSetupView: UIScrollView {
     }()
     
     private(set) lazy var searchAppsButton: UIButton = {
+        let button = ButtonFactory.mediumButton(
+            titleKey: String.LocalizedKey.widgetSetupViewSearchAppsButtonTitle,
+            image: UIImage(systemName: "magnifyingglass"),
+            imagePointSize: 17,
+            backgroundColor: .carrotOrange
+        )
         var config = UIButton.Configuration.filled()
         config.baseBackgroundColor = .carrotOrange
         config.title = .localized(for: .widgetSetupViewSearchAppsButtonTitle)
@@ -66,9 +72,9 @@ class WidgetSetupView: UIScrollView {
         config.imagePadding = 10
         
         let view = UIButton(configuration: config)
-        view.addTarget(self, action: #selector(handleSearchButtonPressed), for: .touchUpInside)
+        button.addTarget(self, action: #selector(handleSearchButtonPressed), for: .touchUpInside)
         
-        return view
+        return button
     }()
     
     private(set) lazy var selectedAppsCollectionView: UICollectionView = {
@@ -98,19 +104,13 @@ class WidgetSetupView: UIScrollView {
     }()
     
     private(set) lazy var nextViewButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = .blueberry
-        config.title = .localized(for: .next)
-        config.imagePlacement = .trailing
-        config.image = UIImage(systemName: "arrow.right")
-        config.imagePadding = 10
-        config.preferredSymbolConfigurationForImage = .init(pointSize: 20, weight: .bold)
-        config.baseForegroundColor = .white
+        let button = ButtonFactory.smallButton(
+            titleKey: String.LocalizedKey.next,
+            image: UIImage(systemName: "arrow.right")
+        )
         
-        let view = UIButton(configuration: config)
-        
-        view.addTarget(self, action: #selector(handleNextButtonPressed), for: .touchUpInside)
-        view.configurationUpdateHandler = { [weak self] btn in
+        button.addTarget(self, action: #selector(handleNextButtonPressed), for: .touchUpInside)
+        button.configurationUpdateHandler = { [weak self] btn in
             guard let self = self, var config = btn.configuration else { return }
             
             btn.isEnabled = self.isStyleSelected && self.hasAppsSelected
@@ -119,14 +119,19 @@ class WidgetSetupView: UIScrollView {
             case .disabled:
                 config.background.backgroundColor = .systemGray2
                 
+            case .highlighted:
+                button.transform = .init(scaleX: 0.97, y: 0.97)
+                button.alpha = 0.67
             default:
+                button.transform = .identity
+                button.alpha = 1
                 config.background.backgroundColor = .blueberry
             }
             
             btn.configuration = config
         }
         
-        return view
+        return button
     }()
     
     // MARK: - Actions
@@ -282,8 +287,6 @@ class WidgetSetupView: UIScrollView {
         
         nextViewButton.snp.makeConstraints { make in
             make.right.equalToSuperview()
-            make.width.equalTo(160)
-            make.height.equalTo(45)
             make.bottom.equalToSuperview().offset(-20)
         }
     }


### PR DESCRIPTION
## Issue Reference

This PR closes #241 by refactoring buttons across the app to use a centralized `ButtonFactory`.

## Summary

1. **Button Refactoring**:
   - Updated buttons in multiple views (`WidgetSetupView`, `WidgetEditorView`, `WelcomeView`, etc.) to be created via a new `ButtonFactory`.
   - The `ButtonFactory` ensures that all buttons share consistent styles, making maintenance easier and the UI more uniform.
   
2. **Default Values in Button Factory**:
   - Added default values to the `ButtonFactory` to streamline button creation, reducing the need for redundant configurations.

3. **Other Changes**:
   - Removed unnecessary code from views that was previously used for custom button creation.
   - Made the button used in the Help View also leverage the `ButtonFactory`.

## Testing

- Verified all buttons visually in each of the views to ensure they match the intended design.
- Confirmed that any default button styles set by the `ButtonFactory` are applied consistently throughout the app.