### PR TITLE
Embedded `RequestScreenTimeView` in `UIScrollView`

### DIFF
--- a/Modulite/Screens/RequestScreenTime/ViewController/RequestScreenTimeViewController.swift
+++ b/Modulite/Screens/RequestScreenTime/ViewController/RequestScreenTimeViewController.swift
@@ -39,6 +39,7 @@ class RequestScreenTimeViewController: UIViewController {
         super.loadView()
         view = requestView
         requestView.setRequestType(to: type)
+        navigationController?.navigationBar.isHidden = true
     }
     
     override func viewDidLoad() {


### PR DESCRIPTION
## Issue Reference

This PR closes #258 by embedding **RequestScreenTimeView** into a `UIScrollView` to enhance accessibility and usability.

## Summary

1. **Transformed RequestScreenTimeView into UIScrollView**:
   - Wrapped the **RequestScreenTimeView** in a `UIScrollView` to ensure that all content is accessible, regardless of the device screen size.
   - This change ensures that users can **scroll** through the content comfortably, even on smaller screens or when larger text sizes are enabled.

2. **Layout Adjustments**:
   - Updated the layout constraints to fit within the scrollable view.
   - Verified that all UI elements maintain their correct positions when scrolling is enabled.

## Testing

- Checked the **RequestScreenTimeView** on multiple devices to ensure the scroll view provides a smooth experience.
- Verified that all components of the view are visible and accessible with the scrolling behavior.