### PR TITLE
Fixed Fonts Not Loading When Opening App With Widget

### DIFF
--- a/Modulite/Screens/Onboarding/Welcome/View/WelcomeView.swift
+++ b/Modulite/Screens/Onboarding/Welcome/View/WelcomeView.swift
@@ -128,7 +128,6 @@ class WelcomeView: UIView {
     }
 }
 
-
 #Preview {
     WelcomeView()
 }

--- a/ModuliteWidget/Info.plist
+++ b/ModuliteWidget/Info.plist
@@ -9,5 +9,14 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>PixelOperator8-Bold.ttf</string>
+		<string>SpaceGrotesk-Medium.ttf</string>
+		<string>SpaceGrotesk-Light.ttf</string>
+		<string>SpaceGrotesk-SemiBold.ttf</string>
+		<string>SpaceGrotesk-Regular.ttf</string>
+		<string>SpaceGrotesk-Bold.ttf</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Issue Reference

This PR closes #256 by fixing an issue where fonts were not loaded when the app was launched via the widget. The solution involved adding the font resources to the **Info.plist** of the widget target.

## Summary

1. **Resolved Font Loading Bug**:
   - Fixed the issue where custom fonts were not properly loaded when opening the app from the widget.
   - Added the necessary font files to the **Info.plist** of the widget target, ensuring that they are available regardless of the entry point into the app.

2. **Widget Target Configuration**:
   - Updated the **Info.plist** of the widget target to include the fonts under the key for bundled resources.
   - Verified that the fonts are now accessible and rendered correctly in both the main app and the widget.

## Testing

- Confirmed that all custom fonts load properly when the app is opened from the **widget**.
- Tested both launching the app directly and through the widget to ensure consistent behavior.

## Next Steps

- Monitor any further font-related issues to ensure consistent appearance across all app views and entry points.
- Gather user feedback to verify that the fix resolves the issue on all devices.

