### PR TITLE
Fixed User Interaction During Editor Scroll Animation

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/WidgetEditorView.swift
@@ -295,12 +295,16 @@ class WidgetEditorView: UIScrollView {
     
     func updateCollectionViewConstraints(_ collectionView: UICollectionView, percentage: CGFloat) {
         let offset = 48 * percentage
-        
+
         collectionView.snp.updateConstraints { make in
             make.left.equalToSuperview().offset(-offset)
         }
-        
-        UIView.animate(withDuration: 0.3) {
+
+        UIView.animate(
+            withDuration: 0.3,
+            delay: 0,
+            options: [.curveEaseOut, .allowUserInteraction]
+        ) {
             self.layoutIfNeeded()
         }
     }


### PR DESCRIPTION
## Issue Reference

This PR closes #249 by fixing an issue where **module and color scrolling** would lose user interaction during animations. The fix involved adding the `.allowUserInteraction` option to animations.

## Summary

1. **Fixed User Interaction Loss During Animation**:
   - Resolved the issue where **module and color scroll views** would become unresponsive during animations.
   - Added the `.allowUserInteraction` option to the relevant animations, allowing users to continue interacting with the scroll views even while they are animating.

2. **Improved User Experience**:
   - Users can now interact with the scroll views seamlessly, even while animations are in progress.
   - Ensured that the animations still execute smoothly without blocking input.

## Testing

- Verified that user interaction is maintained during **module and color** scrolling animations.
- Tested across multiple devices to ensure consistent behavior with different animation scenarios.