### PR TITLE
Fix Deep Linking to Open App via Widget When Not Running in Background

### DIFF
--- a/Modulite/AppDelegate/AppDelegate.swift
+++ b/Modulite/AppDelegate/AppDelegate.swift
@@ -24,6 +24,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // MARK: UISceneSession Lifecycle
+    func application(
+        _ application: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
+        guard let scene = application.connectedScenes.first as? UIWindowScene,
+              let sceneDelegate = scene.delegate as? SceneDelegate else {
+            return false
+        }
+        return sceneDelegate.handleDeepLink(url: url)
+    }
 
     func application(
         _ application: UIApplication,

--- a/Modulite/AppDelegate/SceneDelegate.swift
+++ b/Modulite/AppDelegate/SceneDelegate.swift
@@ -13,6 +13,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     lazy var router = SceneDelegateRouter(window: window!)
     lazy var coordinator = RootTabCoordinator(router: router)
 
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        window = UIWindow(windowScene: windowScene)
+        coordinator.present(animated: true, onDismiss: nil)
+        
+        if let url = connectionOptions.urlContexts.first?.url {
+            handleDeepLink(url: url)
+        }
+    }
+
     // MARK: - Handle Deeplink
     func scene(
         _ scene: UIScene,
@@ -23,18 +38,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         
         handleDeepLink(url: url)
-
     }
 
     @discardableResult
-    private func handleDeepLink(url: URL) -> Bool {
+    func handleDeepLink(url: URL) -> Bool {
         guard let scheme = url.scheme, scheme == "moduliteapp" else {
             print("Invalid URL scheme: \(url.scheme ?? "nil")")
             return false
         }
 
-        guard let host = url.host(), host == "app" else {
-            print("Invalid URL host: \(url.host() ?? "nil")")
+        guard let host = url.host, host == "app" else {
+            print("Invalid URL host: \(url.host ?? "nil")")
             return false
         }
         
@@ -59,26 +73,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         return true
     }
+
     private func performOpenAppAction(with urlScheme: String, completion: @escaping () -> Void) {
         print("Opening app with urlScheme: \(urlScheme)")
-        UIApplication.shared.open(URL(string: urlScheme)!) { _ in
-            completion()
+        if let url = URL(string: urlScheme) {
+            UIApplication.shared.open(url) { _ in
+                completion()
+            }
+        } else {
+            print("Invalid URL for scheme: \(urlScheme)")
         }
-    }
-    
-    func scene(
-        _ scene: UIScene,
-        willConnectTo session: UISceneSession,
-        options connectionOptions: UIScene.ConnectionOptions
-    ) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let windowScene = (scene as? UIWindowScene) else { return }
-        
-        window = UIWindow(windowScene: windowScene)
-        coordinator.present(animated: true, onDismiss: nil)
-        
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Modulite/Components/Gradients/GradientButton.swift
+++ b/Modulite/Components/Gradients/GradientButton.swift
@@ -5,7 +5,6 @@
 //  Created by André Wozniack on 02/11/24.
 //
 
-
 import UIKit
 import SnapKit
 


### PR DESCRIPTION
# Fix Deep Linking to Open App via Widget When Not Running in Background

This PR closes #223 and resolves an issue with deep linking from widgets, ensuring the app can open correctly even when it is not running in the background. This adjustment allows users to launch the app via widget links reliably, regardless of the app’s current state.

## Changes

1. **Modifications in `AppDelegate.swift`**
   - **Added URL handling for widget-triggered launches:** Implemented `application(_:open:options:)` to handle URLs from widgets even if the app is not in the background. This function forwards the received URL to `SceneDelegate` to be processed appropriately.

2. **Modifications in `SceneDelegate.swift`**
   - **Enhanced `handleDeepLink(url:)` function:** Refined `handleDeepLink(url:)` to enable it to be used by both `AppDelegate` and `SceneDelegate`, allowing consistent URL processing from widget interactions. The function now validates the URL’s scheme and host to ensure correct redirection.
   - **Scene startup URL verification:** Added a check in `scene(_:willConnectTo:options:)` to process URLs received from widgets at app launch, ensuring proper handling when the app is opened from a widget.

## Testing

- Verified that URLs from widgets open the app correctly when it is not running in the background.
- Tested deep linking to ensure accurate redirection to targeted content regardless of app state.

