### PR TITLE
Implemented Automatic Scrolling For Selected Options

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDelegate.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/Extensions/WidgetEditorViewController+UICollectionViewDelegate.swift
@@ -62,6 +62,11 @@ extension WidgetEditorViewController: UICollectionViewDelegate {
             selectStyleCell(style: style)
             viewModel.applyStyleToSelectedModule(style)
             editorView.widgetLayoutCollectionView.reloadData()
+            editorView.moduleStyleCollectionView.scrollToItem(
+                at: indexPath,
+                at: .centeredHorizontally,
+                animated: true
+            )
             
         case editorView.moduleColorCollectionView:
             // MARK: - Handle module color touch
@@ -74,6 +79,11 @@ extension WidgetEditorViewController: UICollectionViewDelegate {
             selectColorCell(color: color)
             viewModel.applyColorToSelectedModule(color)
             editorView.widgetLayoutCollectionView.reloadData()
+            editorView.moduleColorCollectionView.scrollToItem(
+                at: indexPath,
+                at: .centeredHorizontally,
+                animated: true
+            )
             
         default: return
             
@@ -145,5 +155,27 @@ extension WidgetEditorViewController: UICollectionViewDelegate {
         
         selectStyleCell(style: selectedStyle)
         selectColorCell(color: selectedColor)
+        
+        scrollToSelectedOptions()
+    }
+    
+    private func scrollToSelectedOptions() {
+        guard let styleIndex = viewModel.getIndexForSelectedStyle(),
+              let colorIndex = viewModel.getIndexForSelectedColor()
+        else { return }
+        
+        let styleIndexPath = IndexPath(item: styleIndex, section: 0)
+        editorView.moduleStyleCollectionView.scrollToItem(
+            at: styleIndexPath,
+            at: .centeredHorizontally,
+            animated: true
+        )
+        
+        let colorIndexPath = IndexPath(item: colorIndex, section: 0)
+        editorView.moduleColorCollectionView.scrollToItem(
+            at: colorIndexPath,
+            at: .centeredHorizontally,
+            animated: true
+        )
     }
 }

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
@@ -116,7 +116,7 @@ class WidgetEditorViewController: UIViewController {
         }
     }
     
-    func setupNavigationBar() {
+    private func setupNavigationBar() {
         guard isCreatingNewWidget else { return }
         
         navigationItem.backAction = UIAction { [weak self] _ in

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
@@ -25,6 +25,16 @@ class WidgetEditorViewModel: NSObject {
     
     // MARK: - Getters
     
+    func getIndexForSelectedStyle() -> Int? {
+        guard let selectedStyle = getStyleFromSelectedModule() else { return nil }
+        return getAvailableStyles().firstIndex(where: { $0.key == selectedStyle.key })
+    }
+
+    func getIndexForSelectedColor() -> Int? {
+        guard let selectedColor = getColorFromSelectedModule() else { return nil }
+        return getAvailableColors().firstIndex(of: selectedColor)
+    }
+    
     func getWidgetId() -> UUID {
         builder.getWidgetId()
     }

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
@@ -58,9 +58,10 @@ class WidgetSetupViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        guard isOnboarding else { return }
+        scrollToSelectedStyle()
+
+        if isOnboarding { setupTipObservers() }
         
-        setupTipObservers()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -380,6 +381,8 @@ extension WidgetSetupViewController: UICollectionViewDelegate {
                 didMakeChanges = true
                 setSetupViewStyleSelected(to: true)
                 delegate?.widgetSetupViewControllerDidSelectWidgetStyle(self, style: style)
+                scrollToSelectedStyle()
+                
             } else {
                 delegate?.widgetSetupViewControllerShouldPresentPurchasePreview(self, for: widgetStyle)
             }
@@ -390,6 +393,16 @@ extension WidgetSetupViewController: UICollectionViewDelegate {
             
         default: return
         }
+    }
+    
+    private func scrollToSelectedStyle() {
+        guard let selectedStyleIndex = viewModel.getIndexForSelectedStyle() else { return }
+        let selectedIndexPath = IndexPath(item: selectedStyleIndex, section: 1)
+        setupView.stylesCollectionView.scrollToItem(
+            at: selectedIndexPath,
+            at: .centeredHorizontally,
+            animated: true
+        )
     }
 }
 

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
@@ -23,6 +23,11 @@ class WidgetSetupViewModel: NSObject {
     @Published private(set) var selectedApps: [AppInfo] = []
     
     // MARK: - Getters
+    func getIndexForSelectedStyle() -> Int? {
+        guard let selectedStyle = selectedStyle else { return nil }
+        return widgetStyles.firstIndex(where: { $0.key == selectedStyle.key })
+    }
+
     func isStyleSelected() -> Bool {
         selectedStyle != nil
     }
@@ -95,5 +100,4 @@ class WidgetSetupViewModel: NSObject {
             style.isPurchased = PurchasedSkinsManager.shared.isSkinPurchased(style.key.rawValue)
         }
     }
-        
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #264 by implementing automatic scrolling for the selected options in **WidgetSetupView** and **WidgetEditorView**.

## Summary

1. **Auto-Scroll to Selected Options**:
   - Implemented logic to **automatically scroll** to the selected module and color options in both **WidgetSetupView** and **WidgetEditorView**.
   - This enhancement ensures that when users edit or revisit a widget, the current selections are clearly visible, providing a more intuitive and user-friendly experience.

2. **Improved User Experience**:
   - Users can now easily see which options are currently selected without manually scrolling, which simplifies the editing process and enhances usability.

## Testing

- Verified that the **WidgetSetupView** and **WidgetEditorView** automatically scroll to the selected module and color when opened.
- Tested the scrolling behavior to ensure it performs smoothly across various screen sizes and scenarios, including switching between different options.