### PR TITLE
Fixed

### DIFF
--- a/Modulite/Coordinators/StylePreview/StylePreviewCoordinator.swift
+++ b/Modulite/Coordinators/StylePreview/StylePreviewCoordinator.swift
@@ -13,9 +13,13 @@ class StylePreviewCoordinator: Coordinator {
     var router: Router
     var style: WidgetStyle = WidgetStyleFactory.styleForKey(.analog)
     
+    var onSelect: ((WidgetStyle) -> Void)?
+    
     func present(animated: Bool, onDismiss: (() -> Void)?) {
-        let viewController = StylePreviewViewController(style: style)
-        router.present(viewController, animated: animated)
+        let vc = StylePreviewViewController(style: style)
+        vc.delegate = self
+        
+        router.present(vc, animated: animated)
     }
     
     init(router: Router) {
@@ -25,5 +29,14 @@ class StylePreviewCoordinator: Coordinator {
     init(style: WidgetStyle, router: Router) {
         self.style = style
         self.router = router
+    }
+}
+
+extension StylePreviewCoordinator: StylePreviewViewControllerDelegate {
+    func stylePreviewViewControllerDidPressUseStyle(
+        _ viewController: StylePreviewViewController
+    ) {
+        onSelect?(style)
+        dismiss(animated: true)
     }
 }

--- a/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator+WidgetSetupViewControllerDelegate.swift
+++ b/Modulite/Coordinators/WidgetBuilder/WidgetBuilderCoordinator+WidgetSetupViewControllerDelegate.swift
@@ -121,9 +121,11 @@ extension WidgetBuilderCoordinator: WidgetSetupViewControllerDelegate {
         
         let coordinator = StylePreviewCoordinator(style: style, router: router)
         
-        presentChild(coordinator, animated: true) {
+        coordinator.onSelect = { style in
             viewController.selectStyle(style)
         }
+        
+        presentChild(coordinator, animated: true)
     }
     
     func widgetSetupViewControllerShouldPresentPurchasePreview(

--- a/Modulite/Screens/WidgetConfiguration/StylePreview/View/StylePreviewView.swift
+++ b/Modulite/Screens/WidgetConfiguration/StylePreview/View/StylePreviewView.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 class StylePreviewView: UIView {
     
-    var selectStyleButtonPressed: (() -> Void)?
+    var onSelectStylePressed: (() -> Void)?
     var updateSelectedStyleIndex: ((_ index: Int) -> Void)?
     
     // MARK: - Subviews
@@ -118,13 +118,13 @@ class StylePreviewView: UIView {
     // MARK: - Actions
     
     @objc func didPressUseButton() {
-        selectStyleButtonPressed?()
+        onSelectStylePressed?()
     }
     
     @objc func didChangePageControl() {
         let pageIndex = pageControl.currentPage
         let currentOffset = collectionView.contentOffset.x / collectionView.frame.width
-        let animated = abs(currentOffset - CGFloat(pageIndex)) == 1 // Apenas anima se o salto for de uma página
+        let animated = abs(currentOffset - CGFloat(pageIndex)) == 1
 
         let offsetX = CGFloat(pageIndex) * collectionView.frame.width
         collectionView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: animated)

--- a/Modulite/Screens/WidgetConfiguration/StylePreview/ViewController/StylePreviewViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/StylePreview/ViewController/StylePreviewViewController.swift
@@ -7,7 +7,15 @@
 
 import UIKit
 
+protocol StylePreviewViewControllerDelegate: AnyObject {
+    func stylePreviewViewControllerDidPressUseStyle(
+        _ viewController: StylePreviewViewController
+    )
+}
+
 class StylePreviewViewController: UIViewController {
+    
+    // MARK: - Properties
     
     private var styleView = StylePreviewView()
     private var viewModel = StylePreviewViewModel()
@@ -16,6 +24,10 @@ class StylePreviewViewController: UIViewController {
     
     private var imageNames: [String] = []
     private var texts: [String] = []
+    
+    weak var delegate: StylePreviewViewControllerDelegate?
+    
+    // MARK: - Initializers
     
     init(style: WidgetStyle) {
         self.style = style
@@ -26,6 +38,7 @@ class StylePreviewViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Lifecycle
     override func loadView() {
         view = styleView
         setupCollectionView()
@@ -34,11 +47,13 @@ class StylePreviewViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureView()
-        
-        styleView.selectStyleButtonPressed = { [weak self] in
-            guard let self = self else { return }
-            self.onStyleSelected?(self.style)
-        }
+        setupViewActions()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupViewActions() {
+        styleView.onSelectStylePressed = didPressSelectStyle
     }
     
     private func setupCollectionView() {
@@ -65,10 +80,15 @@ class StylePreviewViewController: UIViewController {
         styleView.pageControl.numberOfPages = imageNames.count
         styleView.collectionView.reloadData()
     }
+    
+    // MARK: - Actions
+    private func didPressSelectStyle() {
+        delegate?.stylePreviewViewControllerDidPressUseStyle(self)
+    }
 }
 
+// MARK: - UICollectionViewDataSource
 extension StylePreviewViewController: UICollectionViewDataSource {
-    // MARK: - UICollectionViewDataSource
     func collectionView(
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int


### PR DESCRIPTION
## Issue Reference

This PR closes #234 by fixing a bug where the selected style was not properly applied in **WidgetSetupView** after clicking "Use This Style" in `StylePreviewView`.

## Summary

1. **Fixed Style Selection Issue**:
   - Resolved the bug that caused the selected style in `StylePreviewView` to not be applied when returning to **WidgetSetupView**.
   - Updated the selection logic to ensure that the chosen style is consistently reflected in **WidgetSetupView**.

2. **Synchronized State Between Views**:
   - Improved synchronization between `StylePreviewView` and **WidgetSetupView**, ensuring that changes made in the style preview are accurately carried over to the widget setup screen.

## Testing

- Verified that selecting a style in `StylePreviewView` correctly updates the selection in **WidgetSetupView** after pressing "Use This Style".
- Tested different scenarios, including switching between multiple styles and verifying that the correct style is applied.