### PR TITLE
Onboarding is Now Set Completed If User Presses Start

### DIFF
--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -33,6 +33,8 @@ class HomeViewController: UIViewController {
     
     // MARK: - Lifecycle
     override func loadView() {
+        super.loadView()
+        
         self.view = homeView
         homeView.setCollectionViewDelegates(to: self)
         homeView.setCollectionViewDataSources(to: self)

--- a/Modulite/Screens/Onboarding/Welcome/ViewController/WelcomeViewController.swift
+++ b/Modulite/Screens/Onboarding/Welcome/ViewController/WelcomeViewController.swift
@@ -37,6 +37,8 @@ class WelcomeViewController: UIViewController {
     
     // MARK: - Actions
     private func didPressStart() {
+        UserPreference<Onboarding>.shared.set(true, for: .hasCompletedOnboarding)
+        
         delegate?.welcomeViewControllerDidPressStart(self)
     }
 }

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewController/WidgetEditorViewController.swift
@@ -260,7 +260,6 @@ class WidgetEditorViewController: UIViewController {
         delegate?.widgetEditorViewController(self, didSave: widget)
         
         if isOnboarding {
-            UserPreference<Onboarding>.shared.set(true, for: .hasCompletedOnboarding)
             NotificationCenter.default.post(name: .widgetEditorDidFinishOnboarding, object: nil)
         }
     }


### PR DESCRIPTION
## Issue Reference

This PR closes #280 by setting the onboarding status as completed if the user presses "Start", addressing consistency issues with **TipKit**.

## Summary

1. **Onboarding Set as Completed**:
   - Updated the onboarding flow so that when the user presses "Start", the onboarding process is marked as completed.
   - This change ensures that users are not repeatedly prompted with onboarding once they choose to start using the app, which helps to avoid inconsistencies with **TipKit**.

2. **Consistency with TipKit**:
   - The update also prevents certain bugs related to **TipKit**, where tips could become inconsistent if the onboarding status wasn't correctly set.
   - Future versions may revisit this behavior to further refine how **TipKit** integrates with the onboarding flow.

## Testing

- Verified that pressing "Start" during onboarding marks the process as completed, preventing it from reappearing unnecessarily.
- Tested the interaction with **TipKit** to ensure that tips behave correctly after onboarding is set to completed.