### PR TITLE
Implemented Usage Stats in Release Build

### DIFF
--- a/Modulite/Coordinators/RootTabCoordinator.swift
+++ b/Modulite/Coordinators/RootTabCoordinator.swift
@@ -74,12 +74,12 @@ class RootTabCoordinator: Coordinator {
     /// This tab focuses on presenting statistical data and usage patterns to the user.
     /// - Returns: A configured navigation controller for the Usage tab.
     private func configureUsage() -> UINavigationController {
-        #if DEBUG
+//        #if DEBUG
         let vc = UsageViewController()
-        #else
-        let vc = ComingSoonViewController()
-        vc.fillComingSoonView(for: .screenTime)
-        #endif
+//        #else
+//        let vc = ComingSoonViewController()
+//        vc.fillComingSoonView(for: .screenTime)
+//        #endif
         
         let navigationController = UINavigationController(rootViewController: vc)
         

--- a/Modulite/Screens/RequestScreenTime/View/RequestScreenTimeView.swift
+++ b/Modulite/Screens/RequestScreenTime/View/RequestScreenTimeView.swift
@@ -106,12 +106,14 @@ class RequestScreenTimeView: UIView {
     
     private(set) lazy var dismissButton: UIButton = {
         var config = UIButton.Configuration.plain()
+        let textColor = UIColor.charcoalGray.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+        
         config.attributedTitle = AttributedString(
             .localized(for: RequestScreenTimeTexts.requestScreenDismissButtonTitle),
             attributes: AttributeContainer([
                 .font: UIFont(textStyle: .body, weight: .semibold),
-                .foregroundColor: UIColor.charcoalGray,
-                .underlineColor: UIColor.charcoalGray,
+                .foregroundColor: textColor,
+                .underlineColor: textColor,
                 .underlineStyle: NSUnderlineStyle.single.rawValue
             ])
         )


### PR DESCRIPTION
## Issue Reference

This PR closes #282 by making the **Usage Stats** feature available in the release version of the app.

## Summary

1. **Enabled Usage Stats for Release**:
   - Removed the feature flag that was keeping **Usage Stats** hidden in the release version.
   - Made **Usage Stats** fully accessible to all users, allowing them to monitor their app usage patterns directly from the **UsageView**.

## Testing

- Verified that the **Usage Stats** feature is visible and functional in the release build.
- Conducted tests to ensure that all usage data is accurate and displayed correctly across different devices and configurations.