### PR TITLE
Changed Retromac to Free and Removed ModuTouch3

### DIFF
--- a/Modulite/Factories/WidgetStyleFactory.swift
+++ b/Modulite/Factories/WidgetStyleFactory.swift
@@ -129,7 +129,9 @@ extension WidgetStyleFactory {
             defaultColor: .black,
             textConfiguration: textConfig,
             blockedScreenWallpaperImage: .retromacWhiteBlockedWallpaper,
-            homeScreenWallpaperImage: .retromacWhiteWallpaper
+            homeScreenWallpaperImage: .retromacWhiteWallpaper,
+            isPurchased: true,
+            isGrantedByPlus: false
         )
         
         let modules = [
@@ -263,8 +265,7 @@ extension WidgetStyleFactory {
             ModuleStyle(from: style, key: .modutouch3MainPhone),
             ModuleStyle(from: style, key: .modutouch3MainTools)
         ]
-        
-        // Configurando os estilos de módulo no WidgetStyle
+                
         style.setModuleStyles(to: module)
         style.setEmptyStyle(to: ModuleStyle(from: style, key: .modutouch3MainEmpty))
         

--- a/Modulite/Models/Widget/WidgetStyle.swift
+++ b/Modulite/Models/Widget/WidgetStyle.swift
@@ -46,8 +46,8 @@ class WidgetStyle {
         blockedScreenWallpaperImage: UIImage,
         homeScreenWallpaperImage: UIImage,
         imageBlendMode: CGBlendMode? = nil,
-        isPurchased: Bool = false,
-        isGrantedByPlus: Bool = false
+        isPurchased: Bool,
+        isGrantedByPlus: Bool
     ) {
         self.key = key
         self.name = name

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
@@ -15,8 +15,8 @@ class WidgetSetupViewModel: NSObject {
         WidgetStyleFactory.styleForKey(.analog),
         WidgetStyleFactory.styleForKey(.tapedeck),
         WidgetStyleFactory.styleForKey(.retromacWhite),
-        WidgetStyleFactory.styleForKey(.retromacGreen),
-        WidgetStyleFactory.styleForKey(.modutouch3)
+        WidgetStyleFactory.styleForKey(.retromacGreen)
+//        WidgetStyleFactory.styleForKey(.modutouch3)
     ]
     
     @Published private(set) var widgetName: String?


### PR DESCRIPTION
## Issue Reference

This PR closes #295 by making the **RetroMac** skin free and removing **ModuTouch3** in preparation for the new app version release.

## Summary

1. **Changed RetroMac Skin to Free**:
   - Updated the **RetroMac** skin to be available for free to all users.
   - This change aims to provide more value to users and encourage personalization of their widgets without additional cost barriers.

2. **Removed ModuTouch3**:
   - Removed the **ModuTouch3** skin from the app.

3. **App Store Release Preparation**:
   - These changes are part of the preparations for the next release version of the app, focusing on improving the user offering and simplifying the available customization options.

## Testing

- Verified that the **RetroMac** skin is now freely available and can be applied by any user without restrictions.
- Confirmed that **ModuTouch3** no longer appears in the widget customization options.