### PR TITLE
SelectWidget Tip is Always Dismissed When User Selects a Style

### DIFF
--- a/Modulite/Screens/Onboarding/Tips/SelectWidgetStyleTip.swift
+++ b/Modulite/Screens/Onboarding/Tips/SelectWidgetStyleTip.swift
@@ -20,4 +20,10 @@ struct SelectWidgetStyleTip: Tip {
             String.localized(for: OnboardingLocalizedTexts.onboardingSelectWidgetStyleMessage)
         )
     }
+    
+    var rules: [Rule] {
+        #Rule(WidgetSetupViewController.didSelectWidgetStyle) {
+            $0.donations.count == 0
+        }
+    }
 }


### PR DESCRIPTION
## Issue Reference

This PR closes #297 by fixing an issue where the onboarding process would get stuck on a tip, specifically **SelectWidgetStyleTip**.

## Summary

1. **Fixed Onboarding Tip Issue**:
   - Corrected an issue where the onboarding flow would become stuck in the **SelectWidgetStyleTip** step, preventing users from proceeding smoothly.
   - Added a new rule to the `SelectWidgetStyleTip`:
   
     ```swift
     #Rule(WidgetSetupViewController.didSelectWidgetStyle) {
          $0.donations.count == 0
     }
     ```
   - This rule ensures that the tip will only be presented if there are no donations, providing a more straightforward and logical onboarding flow.

2. **Improved Tip Logic**:
   - Updated the tip logic to make sure users can continue through the onboarding process without unnecessary interruptions.
   - Enhanced the logic to make onboarding adapt better to user actions and context.

## Testing

- Verified that the **SelectWidgetStyleTip** now appears and disappears as intended based on the new rule.
- Tested the onboarding flow thoroughly to confirm that users are no longer stuck on any tips.