### PR TITLE
Fixed `WidgetSchema`s Prototype Init Ignoring Attributes

### DIFF
--- a/WidgetStyling/Models/Widget/WidgetSchema.swift
+++ b/WidgetStyling/Models/Widget/WidgetSchema.swift
@@ -71,10 +71,12 @@ public class WidgetSchema: Cloneable {
     
     public required convenience init(_ prototype: WidgetSchema) {
         self.init(
+            id: prototype.id,
             type: prototype.type,
             style: prototype.widgetStyle,
             name: prototype.name,
-            modules: prototype.modules
+            modules: prototype.modules,
+            previewImage: prototype.previewImage
         )
     }
     


### PR DESCRIPTION
## Issue Reference

This PR closes #318, fixing the widget update logic by ensuring that the `WidgetSchema`'s ID is cloned when creating a prototype. Previously, the lack of ID cloning resulted in widgets being duplicated during updates.

## Summary

- **Fix Widget Update Logic**:
  - Modified the cloning mechanism to also include the `id` of `WidgetSchema`.
  - This ensures that the updated widget keeps its original ID, preventing unintended duplications.

- **Next Steps**:
  - Thoroughly test the update and clone processes to confirm widgets are properly updated without duplication.
  - Validate that the change does not affect other functionalities like widget creation or editing.