### PR TITLE
Fixed Updating Widget Style in Edit Mode

### DIFF
--- a/WidgetStyling/Models/Widget/WidgetSchema.swift
+++ b/WidgetStyling/Models/Widget/WidgetSchema.swift
@@ -119,6 +119,8 @@ public class WidgetSchema: Cloneable {
 
 extension WidgetSchema {
     public func changeWidgetStyle(to newStyle: WidgetStyle) {
+        widgetStyle = newStyle
+        
         for i in 0..<modules.count {
             let module = modules[i]
             


### PR DESCRIPTION
## Issue Reference

This PR closes #311, fixing a bug where updating the widget style during editing did not correctly apply the selected style.

## Summary

- **Bug Fix**:
  - Resolved an issue where switching to a different widget style during the edit process didn't reflect the changes properly.
  - The selected style is now accurately applied, and the preview updates accordingly.