### PR TITLE
Load Purchased Styles From StoreKit

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -47,7 +47,6 @@
 		AFBBC50F2C7E459A00A9B256 /* ModuliteWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AFBBC5022C7E459900A9B256 /* ModuliteWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AFDC1A512CB46005008A816D /* ShieldConfigurationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDC1A502CB46005008A816D /* ShieldConfigurationBuilder.swift */; };
 		AFDC1A522CB4600B008A816D /* ShieldConfigurationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDC1A502CB46005008A816D /* ShieldConfigurationBuilder.swift */; };
-		AFE15AB32CD97EFC000A255B /* PurchaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE15AB22CD97EFC000A255B /* PurchaseManager.swift */; };
 		AFE15AB42CD97EFC000A255B /* PurchaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE15AB22CD97EFC000A255B /* PurchaseManager.swift */; };
 		AFE15ABB2CD9A194000A255B /* MultiLineGradientLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE15ABA2CD9A194000A255B /* MultiLineGradientLabelView.swift */; };
 		AFE5D5022CADD4C700503572 /* FamilyControlsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE5D5012CADD4C700503572 /* FamilyControlsManager.swift */; };
@@ -239,6 +238,7 @@
 		B37284762C82997700D9A1E7 /* ImageProcessingFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CDD7062C77C59B00E558F8 /* ImageProcessingFactory.swift */; };
 		B384D9362CE585F000D17B93 /* retromacWhite.json in Resources */ = {isa = PBXBuildFile; fileRef = B384D9352CE585F000D17B93 /* retromacWhite.json */; };
 		B384D9382CE6787B00D17B93 /* modutouch3.json in Resources */ = {isa = PBXBuildFile; fileRef = B384D9372CE6787B00D17B93 /* modutouch3.json */; };
+		B384D9422CE7A64700D17B93 /* WidgetStylingProvider+PurchasedSkins.swift in Sources */ = {isa = PBXBuildFile; fileRef = B384D9402CE7A64700D17B93 /* WidgetStylingProvider+PurchasedSkins.swift */; };
 		B3850BB52C94D1F200F400C0 /* UICollectionViewCell+toggleIsHighlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3850BB42C94D1F200F400C0 /* UICollectionViewCell+toggleIsHighlighted.swift */; };
 		B3850BBB2C963A0500F400C0 /* UIFontExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3850BBA2C963A0500F400C0 /* UIFontExtensionTests.swift */; };
 		B3850BBD2C963BD500F400C0 /* UITextFieldExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3850BBC2C963BD500F400C0 /* UITextFieldExtensionTests.swift */; };
@@ -731,6 +731,7 @@
 		B36927D92C66C2770089F769 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		B384D9352CE585F000D17B93 /* retromacWhite.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = retromacWhite.json; sourceTree = "<group>"; };
 		B384D9372CE6787B00D17B93 /* modutouch3.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = modutouch3.json; sourceTree = "<group>"; };
+		B384D9402CE7A64700D17B93 /* WidgetStylingProvider+PurchasedSkins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetStylingProvider+PurchasedSkins.swift"; sourceTree = "<group>"; };
 		B3850BB42C94D1F200F400C0 /* UICollectionViewCell+toggleIsHighlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+toggleIsHighlighted.swift"; sourceTree = "<group>"; };
 		B3850BBA2C963A0500F400C0 /* UIFontExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensionTests.swift; sourceTree = "<group>"; };
 		B3850BBC2C963BD500F400C0 /* UITextFieldExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextFieldExtensionTests.swift; sourceTree = "<group>"; };
@@ -2686,6 +2687,7 @@
 				B3C6DD782CDE9B28002AEAF7 /* AppData+Extensions.swift */,
 				B3C6DD792CDE9B28002AEAF7 /* WidgetModule+Extensions.swift */,
 				B3C6DD7A2CDE9B28002AEAF7 /* WidgetSchema+Extensions.swift */,
+				B384D9402CE7A64700D17B93 /* WidgetStylingProvider+PurchasedSkins.swift */,
 			);
 			path = WidgetStylingExtensions;
 			sourceTree = "<group>";
@@ -3324,7 +3326,6 @@
 				B363B57D2CE3E0E8002912CC /* WidgetModule+Extensions.swift in Sources */,
 				B32B60A62C838ED9007DDCE3 /* UILabel+AppNameConfiguration.swift in Sources */,
 				B3987E102CA38A9C00896414 /* MainWidgetView.swift in Sources */,
-				AFE15AB32CD97EFC000A255B /* PurchaseManager.swift in Sources */,
 				B37284752C82996600D9A1E7 /* String+LocalizedKey.swift in Sources */,
 				B3987E212CA4801600896414 /* UIColorValueTransformer.swift in Sources */,
 				B3987E202CA3A3BC00896414 /* MainWidgetModuleButton.swift in Sources */,
@@ -3547,6 +3548,7 @@
 				B30201752CC8C9D800301646 /* AsteriskText.swift in Sources */,
 				B3D1B7D12CB7024700DFC4F5 /* FAQSummaryStackView.swift in Sources */,
 				B32F3BFE2CD70A0F000F4825 /* SpaceGrotesk.swift in Sources */,
+				B384D9422CE7A64700D17B93 /* WidgetStylingProvider+PurchasedSkins.swift in Sources */,
 				B3EB15BB2C7E5DC5003B1960 /* UILabel+AppNameConfiguration.swift in Sources */,
 				B34C63072CD2D835004E014B /* DragModuleTip.swift in Sources */,
 				B34F3E2B2C6E83800041D7BD /* UIFont+TraitedTextStyle.swift in Sources */,

--- a/Modulite/AppDelegate/AppDelegate.swift
+++ b/Modulite/AppDelegate/AppDelegate.swift
@@ -18,6 +18,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         CoreDataPersistenceController.shared.executeInitialSetup()
         
+        PurchaseManager.shared.initialize()
+        
         try? Tips.configure([.displayFrequency(.immediate)])
         
         return true

--- a/Modulite/Extensions/WidgetStylingExtensions/WidgetStylingProvider+PurchasedSkins.swift
+++ b/Modulite/Extensions/WidgetStylingExtensions/WidgetStylingProvider+PurchasedSkins.swift
@@ -1,0 +1,15 @@
+//
+//  WidgetStylingProvider+PurchasedSkins.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 15/11/24.
+//
+
+import WidgetStyling
+
+extension WidgetStyleProvider {
+    convenience init(purchasedSkins: Set<String>) throws {
+        try self.init()
+        setPurchasedStyles(purchasedSkins)
+    }
+}

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewController/Extensions/WidgetSetupViewController+UICollectionViewDelegate.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewController/Extensions/WidgetSetupViewController+UICollectionViewDelegate.swift
@@ -35,7 +35,7 @@ extension WidgetSetupViewController: UICollectionViewDelegate {
         
         Task {
             do {
-                guard let product = purchaseManager.getProduct(id: productID) else {
+                guard let product = purchaseManager.getProduct(withID: productID) else {
                     print("Product not found in purchase manager.")
                     return
                 }

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
@@ -14,7 +14,9 @@ class WidgetSetupViewModel: NSObject {
     
     @Published private(set) var widgetStyles: [WidgetStyle] = {
         do {
-            let provider = try WidgetStyleProvider()
+            let provider = try WidgetStyleProvider(
+                purchasedSkins: PurchaseManager.shared.purchasedSkins
+            )
             return provider.getAllStyles()
             
         } catch {

--- a/Modulite/Singleton/Skins/PurchaseManager.swift
+++ b/Modulite/Singleton/Skins/PurchaseManager.swift
@@ -5,122 +5,128 @@
 //  Created by André Wozniack on 04/11/24.
 //
 
+import Foundation
 import StoreKit
 import WidgetStyling
 
-final class PurchaseManager: NSObject, ObservableObject {
+final class PurchaseManager {
     static let shared = PurchaseManager()
     
-    @Published var purchasedSkins: Set<String> = []
+    @Published private(set) var products: [Product] = []
+    @Published private(set) var purchasedSkins: Set<String> = []
     
-    private(set) var products: [Product] = []
+    // MARK: - Initialization
     
-    private override init() {
-        super.init()
-        fetchPurchasedProducts()
-        startObservingTransactionUpdates()
-        
-        Task { self.products = await fetchProducts() }
-    }
+    private init() { }
     
-    // MARK: - Produto e Compras
-
-    func fetchProducts() async -> [Product] {
-        do {
-            let provider = try WidgetStyleProvider()
-            let productIDs = provider.getAllStyles().map { $0.identifier }
-            return try await Product.products(for: productIDs)
-        } catch {
-            return []
+    @MainActor func initialize() {
+        Task {
+            await updatePurchasedProducts()
+            await fetchProducts()
+            startObservingTransactionUpdates()
         }
     }
-
-    func fetchPurchasedProducts() async throws {
-        for await result in Transaction.currentEntitlements {
-            switch result {
-            case .verified(let transaction):
-                await handlePurchased(transaction: transaction)
-            case .unverified:
-                break
+    
+    // MARK: - Fetch Products
+    
+    private func fetchProducts() async {
+        do {
+            let provider = try WidgetStyleProvider(purchasedSkins: purchasedSkins)
+            let productIDs = provider.getAllStyles().map { $0.identifier }
+            let storeProducts = try await Product.products(for: productIDs)
+            await MainActor.run {
+                self.products = storeProducts
+            }
+        } catch {
+            print("Failed to fetch products: \(error.localizedDescription)")
+            await MainActor.run {
+                self.products = []
             }
         }
     }
     
-    func getProduct(id: String) -> Product? {
-        return products.first(where: { $0.id == id })
+    // MARK: - Update Purchased Products
+    
+    private func updatePurchasedProducts() async {
+        let purchasedIDs = await Transaction.currentEntitlements.reduce(
+            into: Set<String>()
+        ) { result, transactionResult in
+            switch transactionResult {
+            case .verified(let transaction):
+                result.insert(transaction.productID)
+            case .unverified(let transaction, _):
+                print("Unverified transaction for product ID: \(transaction.productID)")
+            }
+        }
+        await MainActor.run {
+            self.purchasedSkins = purchasedIDs
+        }
     }
-
+    
+    // MARK: - Purchase Product
+    
     func purchase(product: Product) async throws {
         let result = try await product.purchase()
         switch result {
         case .success(let verification):
             switch verification {
             case .verified(let transaction):
-                await handlePurchased(transaction: transaction)
-            case .unverified:
+                await handleTransaction(transaction)
+            case .unverified(let transaction, let verificationError):
+                print("Unverified transaction: \(transaction), error: \(verificationError.localizedDescription)")
                 throw PurchaseError.failedVerification
             }
         case .userCancelled:
             throw PurchaseError.userCancelled
-
         case .pending:
             throw PurchaseError.pending
-
         @unknown default:
             throw PurchaseError.unknown
         }
     }
-
+    
+    // MARK: - Restore Purchases
+    
     func restorePurchases() async throws {
-        for await result in Transaction.currentEntitlements {
-            switch result {
-            case .verified(let transaction):
-                await handlePurchased(transaction: transaction)
-            case .unverified:
-                throw PurchaseError.failedVerification
-            }
-        }
+        try await AppStore.sync()
+        await updatePurchasedProducts()
     }
     
-    // MARK: - Atualizações de Transação
-
+    // MARK: - Transaction Handling
+    
     private func startObservingTransactionUpdates() {
         Task {
             for await result in Transaction.updates {
                 switch result {
                 case .verified(let transaction):
-                    await handlePurchased(transaction: transaction)
-                case .unverified:
-                    print("Erro de verificação de transação")
+                    await self.handleTransaction(transaction)
+                case .unverified(_, let verificationError):
+                    print("Transaction verification failed: \(verificationError.localizedDescription)"
+                    )
                 }
             }
         }
     }
     
-    private func handlePurchased(transaction: Transaction) async {
-        purchasedSkins.insert(transaction.productID)
-        savePurchasedSkins()
+    private func handleTransaction(_ transaction: Transaction) async {
+        _ = await MainActor.run {
+            self.purchasedSkins.insert(transaction.productID)
+        }
         await transaction.finish()
     }
     
-    // MARK: - Persistência
-
-    private func savePurchasedSkins() {
-        let defaults = UserDefaults.standard
-        defaults.set(Array(purchasedSkins), forKey: "purchasedSkins")
-    }
-
-    private func fetchPurchasedProducts() {
-        let defaults = UserDefaults.standard
-        if let savedSkins = defaults.array(forKey: "purchasedSkins") as? [String] {
-            purchasedSkins = Set(savedSkins)
-        }
+    // MARK: - Helper Methods
+    
+    func isSkinPurchased(_ skinID: String) -> Bool {
+        return purchasedSkins.contains(skinID)
     }
     
-    func isSkinPurchased(for skin: String) -> Bool {
-        purchasedSkins.contains(skin)
+    func getProduct(withID id: String) -> Product? {
+        return products.first(where: { $0.id == id })
     }
 }
+
+// MARK: - PurchaseError Enum
 
 enum PurchaseError: Error {
     case failedVerification

--- a/WidgetStyling/Providers/WidgetStyleProvider.swift
+++ b/WidgetStyling/Providers/WidgetStyleProvider.swift
@@ -22,6 +22,15 @@ public class WidgetStyleProvider {
     }
     
     // MARK: - Methods
+    public func setPurchasedStyles(_ styleIds: Set<String>) {
+        styles = styles.map {
+            if styleIds.contains($0.identifier) {
+                $0.updateIsPurchased(to: true)
+            }
+            return $0
+        }
+    }
+    
     private func loadStyles() throws {
         let bundle = Bundle(for: Self.self)
         

--- a/WidgetStyling/Providers/WidgetStyleProvider.swift
+++ b/WidgetStyling/Providers/WidgetStyleProvider.swift
@@ -24,9 +24,9 @@ public class WidgetStyleProvider {
     // MARK: - Methods
     public func setPurchasedStyles(_ styleIds: Set<String>) {
         styles = styles.map {
-            $0.updateIsPurchased(
-                to: styleIds.contains($0.identifier)
-            )
+            if styleIds.contains($0.identifier) {
+                $0.updateIsPurchased(to: true)
+            }
             return $0
         }
     }

--- a/WidgetStyling/Providers/WidgetStyleProvider.swift
+++ b/WidgetStyling/Providers/WidgetStyleProvider.swift
@@ -24,9 +24,9 @@ public class WidgetStyleProvider {
     // MARK: - Methods
     public func setPurchasedStyles(_ styleIds: Set<String>) {
         styles = styles.map {
-            if styleIds.contains($0.identifier) {
-                $0.updateIsPurchased(to: true)
-            }
+            $0.updateIsPurchased(
+                to: styleIds.contains($0.identifier)
+            )
             return $0
         }
     }


### PR DESCRIPTION
## Issue Reference

This PR closes #326, fixing the loading of purchased/non-purchased status for widget styles by updating the `PurchaseManager` to utilize the StoreKit API.

## Summary

- **Fix**:
  - Updated `PurchaseManager` to fetch purchase status using the StoreKit API, ensuring that styles accurately reflect their purchased status.
  - Removed outdated methods that caused discrepancies in displaying purchased and non-purchased styles.

- **Next Steps**:
  - Test the integration with StoreKit thoroughly to confirm the reliability of purchase status across different devices.
  - Consider adding UI feedback for users when loading purchase status to improve the experience.