### PR TITLE
Enhancement/330/wrong persisted image size

### DIFF
--- a/Modulite/Models/Modules/Persistence/PersistentWidgetModule+CoreDataProperties.swift
+++ b/Modulite/Models/Modules/Persistence/PersistentWidgetModule+CoreDataProperties.swift
@@ -21,6 +21,7 @@ extension PersistentWidgetModule {
 extension PersistentWidgetModule {
     static func from(
         module: WidgetModule,
+        imageURL: URL,
         schema: WidgetSchema,
         using managedObjectContext: NSManagedObjectContext
     ) -> PersistentWidgetModule {
@@ -31,24 +32,7 @@ extension PersistentWidgetModule {
         persistedModule.urlScheme = module.urlScheme
         persistedModule.styleIdentifier = module.style.identifier
         persistedModule.selectedColor = module.color
-        
-        let strategy: WidgetTypeStrategy = if schema.type == .main {
-            MainWidgetStrategy()
-        } else {
-            AuxWidgetStrategy()
-        }
-        
-        let moduleImage = module.createCompleteImage(
-            for: strategy
-        )
-        
-        let persistedModuleImageURL = FileManagerImagePersistenceController.shared.saveModuleImage(
-            image: moduleImage,
-            for: schema.id,
-            moduleIndex: module.position
-        )
-        
-        persistedModule.imageURL = persistedModuleImageURL
+        persistedModule.imageURL = imageURL
         
         return persistedModule
     }

--- a/Modulite/Models/Widget/Persistence/PersistentWidgetSchema+CoreDataProperties.swift
+++ b/Modulite/Models/Widget/Persistence/PersistentWidgetSchema+CoreDataProperties.swift
@@ -24,6 +24,7 @@ extension PersistentWidgetSchema {
     static func from(
         schema: WidgetSchema,
         widgetImage: UIImage,
+        moduleImages: [Int: UIImage],
         using managedObjectContext: NSManagedObjectContext
     ) -> PersistentWidgetSchema {
         let persistedSchema = PersistentWidgetSchema(context: managedObjectContext)
@@ -41,8 +42,19 @@ extension PersistentWidgetSchema {
         persistedSchema.previewImageUrl = widgetImageURL
         
         for module in schema.modules {
+            guard let image = moduleImages[module.position] else {
+                fatalError("Fatal error: module image not found.")
+            }
+            
+            let imageURL = FileManagerImagePersistenceController.shared.saveModuleImage(
+                image: image,
+                for: schema.id,
+                moduleIndex: module.position
+            )
+            
             let persistentModule = PersistentWidgetModule.from(
                 module: module,
+                imageURL: imageURL,
                 schema: schema,
                 using: managedObjectContext
             )

--- a/Modulite/Screens/WidgetConfiguration/Editor/View/CollectionViewCells/WidgetModuleCell.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/View/CollectionViewCells/WidgetModuleCell.swift
@@ -58,7 +58,7 @@ class WidgetModuleCell: UICollectionViewCell {
         backgroundColor = .clear
         
         addSubviews()
-        setupConstraints(bottomOffset: module.getBottomOffset())
+        setupConstraints(bottomPosition: module.getBottomPosition())
     }
     
     private func addSubviews() {
@@ -66,13 +66,13 @@ class WidgetModuleCell: UICollectionViewCell {
         addSubview(appNameLabel)
     }
     
-    private func setupConstraints(bottomOffset: CGFloat) {
+    private func setupConstraints(bottomPosition: CGFloat) {
         moduleImageView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
         
         appNameLabel.snp.makeConstraints { make in
-            make.bottom.equalTo(snp.bottom).offset(-bottomOffset)
+            make.bottom.equalTo(snp.bottom).multipliedBy(bottomPosition)
             make.height.equalTo(20)
             make.width.equalToSuperview().multipliedBy(0.8)
             make.centerX.equalToSuperview()

--- a/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Editor/ViewModel/WidgetEditorViewModel.swift
@@ -153,9 +153,24 @@ class WidgetEditorViewModel: NSObject {
     func saveWidget(from collectionView: UICollectionView) -> WidgetSchema? {
         do {
             let widgetSchema = try builder.build()
+            
+            let widgetImage = collectionView.asImage()
+            
+            var moduleImages: [Int: UIImage] = [:]
+            for cell in collectionView.visibleCells {
+                guard let moduleCell = cell as? WidgetModuleCell else { continue }
+                guard let indexPath = collectionView.indexPath(for: moduleCell) else { continue }
+                
+                let module = widgetSchema.modules[indexPath.item]
+                let moduleImage = moduleCell.asImage()
+                
+                moduleImages[module.position] = moduleImage
+            }
+            
             let persistedSchema = CoreDataPersistenceController.shared.registerOrUpdateWidget(
                 widgetSchema,
-                widgetImage: collectionView.asImage()
+                widgetImage: widgetImage,
+                moduleImages: moduleImages
             )
             
             widgetSchema.previewImage = FileManagerImagePersistenceController.shared.getWidgetImage(

--- a/WidgetStyling/Models/Module/Decodable/ModuleTextConfigurationData.swift
+++ b/WidgetStyling/Models/Module/Decodable/ModuleTextConfigurationData.swift
@@ -23,5 +23,5 @@ struct ModuleTextConfigurationData: Decodable {
     let shouldRemoveSpaces: Bool?
     let prefix: String?
     let suffix: String?
-    let bottomOffset: CGFloat?
+    let bottomRelativePosition: CGFloat?
 }

--- a/WidgetStyling/Models/Module/ModuleTextConfiguration.swift
+++ b/WidgetStyling/Models/Module/ModuleTextConfiguration.swift
@@ -21,7 +21,7 @@ public class ModuleTextConfiguration {
     public var shouldRemoveSpaces: Bool = false
     public var prefix: String?
     public var suffix: String?
-    public var bottomOffset: CGFloat?
+    public var bottomRelativePosition: CGFloat?
 
     // MARK: - Initializers
     static func create(from data: ModuleTextConfigurationData) -> ModuleTextConfiguration {
@@ -65,7 +65,21 @@ public class ModuleTextConfiguration {
         }
         
         if let shadowColorName = data.shadowColorName {
-            configuration.shadowColor = UIColor.fromWidgetStyling(named: shadowColorName)
+            configuration.shadowColor = UIColor.fromWidgetStyling(
+                named: shadowColorName
+            )?.withAlphaComponent(0.25)
+        }
+        
+        if let shadowOffsetWidth = data.shadowOffsetWidth,
+           let shadowOffsetHeight = data.shadowOffsetHeight {
+            configuration.shadowOffset = CGSize(
+                width: shadowOffsetWidth,
+                height: shadowOffsetHeight
+            )
+        }
+        
+        if let shadowBlurRadius = data.shadowBlurRadius {
+            configuration.shadowBlurRadius = shadowBlurRadius
         }
     }
 
@@ -93,8 +107,8 @@ public class ModuleTextConfiguration {
             configuration.textCase = String.TextCase(from: caseString)
         }
         
-        if let bottomOffset = data.bottomOffset {
-            configuration.bottomOffset = bottomOffset
+        if let bottomRelativePosition = data.bottomRelativePosition {
+            configuration.bottomRelativePosition = bottomRelativePosition
         }
     }
     

--- a/WidgetStyling/Models/Widget/WidgetModule.swift
+++ b/WidgetStyling/Models/Widget/WidgetModule.swift
@@ -38,8 +38,8 @@ public class WidgetModule {
     }
     
     // MARK: - Helper functions
-    public func getBottomOffset() -> CGFloat {
-        style.textConfiguration.bottomOffset ?? 0
+    public func getBottomPosition() -> CGFloat {
+        style.textConfiguration.bottomRelativePosition ?? 0
     }
     
     public func canSetColor(to color: UIColor) -> Bool {

--- a/WidgetStyling/WidgetStyles/analog.json
+++ b/WidgetStyling/WidgetStyles/analog.json
@@ -34,7 +34,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.885
                 }
             },
             {
@@ -56,7 +56,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.885
                 }
             },
             {
@@ -78,7 +78,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.885
                 }
             },
             {
@@ -100,7 +100,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.885
                 }
             },
             {
@@ -122,7 +122,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.885
                 }
             }
         ],
@@ -145,7 +145,7 @@
                 "textCase": "lower",
                 "shouldRemoveSpaces": true,
                 "prefix": ".",
-                "bottomOffset": 19
+                "bottomRelativePosition": 0.885
             }
         },
         "auxModules": [
@@ -168,7 +168,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.87
                 }
             },
             {
@@ -190,7 +190,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.87
                 }
             },
             {
@@ -212,7 +212,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.87
                 }
             },
             {
@@ -234,7 +234,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.87
                 }
             },
             {
@@ -256,7 +256,7 @@
                     "textCase": "lower",
                     "shouldRemoveSpaces": true,
                     "prefix": ".",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.87
                 }
             }
         ],
@@ -279,7 +279,7 @@
                 "textCase": "lower",
                 "shouldRemoveSpaces": true,
                 "prefix": ".",
-                "bottomOffset": 19
+                "bottomRelativePosition": 0.87
             }
         }
     },

--- a/WidgetStyling/WidgetStyles/modutouch3.json
+++ b/WidgetStyling/WidgetStyles/modutouch3.json
@@ -26,9 +26,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -42,9 +44,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -58,9 +62,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -74,9 +80,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -90,9 +98,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -106,9 +116,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -122,9 +134,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -138,9 +152,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -154,9 +170,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -170,9 +188,11 @@
                     "fontWeight": "medium",
                     "textColorName": "squidInk",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             }
         ],
@@ -187,9 +207,11 @@
                 "fontWeight": "medium",
                 "textColorName": "squidInk",
                 "shadowColorName": "squidInk",
+                "shadowOffsetHeight": 4,
+                "shadowOffsetWidth": 0,
                 "shadowBlurRadius": 4,
                 "textCase": "capitalized",
-                "bottomOffset": 25
+                "bottomRelativePosition": 0.9
             }
         },
         "auxModules": [
@@ -204,9 +226,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -220,9 +244,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -236,9 +262,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -252,9 +280,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -268,9 +298,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -284,9 +316,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -300,9 +334,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -316,9 +352,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -332,9 +370,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -348,9 +388,11 @@
                     "fontWeight": "medium",
                     "textColorName": "meringue",
                     "shadowColorName": "squidInk",
+                    "shadowOffsetHeight": 4,
+                    "shadowOffsetWidth": 0,
                     "shadowBlurRadius": 4,
                     "textCase": "capitalized",
-                    "bottomOffset": 25
+                    "bottomRelativePosition": 0.9
                 }
             }
         ],
@@ -365,9 +407,11 @@
                 "fontWeight": "medium",
                 "textColorName": "meringue",
                 "shadowColorName": "squidInk",
+                "shadowOffsetHeight": 4,
+                "shadowOffsetWidth": 0,
                 "shadowBlurRadius": 4,
                 "textCase": "capitalized",
-                "bottomOffset": 25
+                "bottomRelativePosition": 0.9
             }
         }
     },

--- a/WidgetStyling/WidgetStyles/retromacGreen.json
+++ b/WidgetStyling/WidgetStyles/retromacGreen.json
@@ -26,7 +26,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -41,7 +41,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -56,7 +56,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -71,7 +71,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -86,7 +86,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -101,7 +101,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -116,7 +116,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -131,7 +131,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -146,7 +146,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -161,7 +161,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -176,7 +176,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -191,7 +191,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -206,7 +206,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -221,7 +221,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -236,7 +236,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -251,7 +251,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -266,7 +266,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -281,7 +281,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -296,7 +296,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -311,7 +311,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -326,7 +326,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -341,7 +341,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -356,7 +356,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -371,7 +371,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -386,7 +386,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -401,7 +401,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -416,7 +416,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             }
@@ -432,7 +432,7 @@
                 "textColorName": "squidInk",
                 "textAlignment": "center",
                 "textCase": "capitalized",
-                "bottomOffset": 19
+                "bottomRelativePosition": 0.9
             },
             "forcedUserInterfaceStyle": "light"
         },
@@ -448,7 +448,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -463,7 +463,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -478,7 +478,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -493,7 +493,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -508,7 +508,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -523,7 +523,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -538,7 +538,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -553,7 +553,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -568,7 +568,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -583,7 +583,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -598,7 +598,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -613,7 +613,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -628,7 +628,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -643,7 +643,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -658,7 +658,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -673,7 +673,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -688,7 +688,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -703,7 +703,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -718,7 +718,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -733,7 +733,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -748,7 +748,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -763,7 +763,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -778,7 +778,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -793,7 +793,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -808,7 +808,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -823,7 +823,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -838,7 +838,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             }
@@ -854,7 +854,7 @@
                 "textColorName": "squidInk",
                 "textAlignment": "center",
                 "textCase": "capitalized",
-                "bottomOffset": 12
+                "bottomRelativePosition": 0.92
             },
             "forcedUserInterfaceStyle": "light"
         }

--- a/WidgetStyling/WidgetStyles/retromacWhite.json
+++ b/WidgetStyling/WidgetStyles/retromacWhite.json
@@ -26,7 +26,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -41,7 +41,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -56,7 +56,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -71,7 +71,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -86,7 +86,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -101,7 +101,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -116,7 +116,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -131,7 +131,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -146,7 +146,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -161,7 +161,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -176,7 +176,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -191,7 +191,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -206,7 +206,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -221,7 +221,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -236,7 +236,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -251,7 +251,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -266,7 +266,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -281,7 +281,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -296,7 +296,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -311,7 +311,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -326,7 +326,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -341,7 +341,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -356,7 +356,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -371,7 +371,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -386,7 +386,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -401,7 +401,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -416,7 +416,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 19
+                    "bottomRelativePosition": 0.9
                 },
                 "forcedUserInterfaceStyle": "light"
             }
@@ -432,7 +432,7 @@
                 "textColorName": "squidInk",
                 "textAlignment": "center",
                 "textCase": "capitalized",
-                "bottomOffset": 19
+                "bottomRelativePosition": 0.9
             },
             "forcedUserInterfaceStyle": "light"
         },
@@ -448,7 +448,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -463,7 +463,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -478,7 +478,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -493,7 +493,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -508,7 +508,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -523,7 +523,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -538,7 +538,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -553,7 +553,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -568,7 +568,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -583,7 +583,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -598,7 +598,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -613,7 +613,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -628,7 +628,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -643,7 +643,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -658,7 +658,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -673,7 +673,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -688,7 +688,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -703,7 +703,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -718,7 +718,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -733,7 +733,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -748,7 +748,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -763,7 +763,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -778,7 +778,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -793,7 +793,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -808,7 +808,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -823,7 +823,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             },
@@ -838,7 +838,7 @@
                     "textColorName": "squidInk",
                     "textAlignment": "center",
                     "textCase": "capitalized",
-                    "bottomOffset": 12
+                    "bottomRelativePosition": 0.92
                 },
                 "forcedUserInterfaceStyle": "light"
             }
@@ -854,7 +854,7 @@
                 "textColorName": "squidInk",
                 "textAlignment": "center",
                 "textCase": "capitalized",
-                "bottomOffset": 12
+                "bottomRelativePosition": 0.92
             },
             "forcedUserInterfaceStyle": "light"
         }

--- a/WidgetStyling/WidgetStyles/tapedeck.json
+++ b/WidgetStyling/WidgetStyles/tapedeck.json
@@ -30,7 +30,7 @@
                     "fontWeight": "bold",
                     "textColorName": "meringue",
                     "textCase": "upper",
-                    "bottomOffset": 16
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -48,7 +48,7 @@
                     "fontWeight": "bold",
                     "textColorName": "meringue",
                     "textCase": "upper",
-                    "bottomOffset": 16
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -66,7 +66,7 @@
                     "fontWeight": "bold",
                     "textColorName": "meringue",
                     "textCase": "upper",
-                    "bottomOffset": 16
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -84,7 +84,7 @@
                     "fontWeight": "bold",
                     "textColorName": "meringue",
                     "textCase": "upper",
-                    "bottomOffset": 16
+                    "bottomRelativePosition": 0.9
                 }
             },
             {
@@ -98,7 +98,7 @@
                     "fontWeight": "bold",
                     "textColorName": "meringue",
                     "textCase": "upper",
-                    "bottomOffset": 16
+                    "bottomRelativePosition": 0.9
                 }
             }
         ],
@@ -113,7 +113,7 @@
                 "fontWeight": "bold",
                 "textColorName": "meringue",
                 "textCase": "upper",
-                "bottomOffset": 16
+                "bottomRelativePosition": 0.9
             }
         },
         "auxModules": [
@@ -128,7 +128,7 @@
                     "fontWeight": "bold",
                     "textColorName": "meringue",
                     "textCase": "upper",
-                    "bottomOffset": 21
+                    "bottomRelativePosition": 0.856
                 }
             },
             {
@@ -142,7 +142,7 @@
                     "fontWeight": "bold",
                     "textColorName": "meringue",
                     "textCase": "upper",
-                    "bottomOffset": 21
+                    "bottomRelativePosition": 0.856
                 }
             },
             {
@@ -156,7 +156,7 @@
                     "fontWeight": "bold",
                     "textColorName": "meringue",
                     "textCase": "upper",
-                    "bottomOffset": 21
+                    "bottomRelativePosition": 0.856
                 }
             }
         ],
@@ -175,7 +175,7 @@
                 "fontWeight": "bold",
                 "textColorName": "meringue",
                 "textCase": "upper",
-                "bottomOffset": 21
+                "bottomRelativePosition": 0.9
             }
         }
     },


### PR DESCRIPTION
## Issue Reference

This PR closes #330 by fixing the text positioning bug in widget modules. Previously, the rendered image sizes differed from the on-screen display, causing inconsistencies in text alignment. Now, the modules rendered on-screen are used to generate saved images, ensuring they match.

## Summary

- **Bug Fix**:
  - Fixed text positioning for multiple styles including:
    - Analog
    - Tapedeck
    - Retromac
    - Modutouch3
  - Adjusted text position parameters to be relative and added shadow parameters to enhance visual consistency.
  - Refactored the code to use visible cells directly for creating images, making sure that the final saved image matches the on-screen widget layout.