### PR TITLE
Fixed Views Being Clipped in `WidgetSetupView`

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/View/WidgetSetupView.swift
@@ -259,7 +259,7 @@ class WidgetSetupView: UIView {
         
         contentView.snp.makeConstraints { make in
             make.edges.equalTo(scrollView.contentLayoutGuide)
-            make.height.width.equalTo(scrollView.frameLayoutGuide)
+            make.width.equalTo(scrollView.frameLayoutGuide)
         }
         
         widgetNameTextField.snp.makeConstraints { make in


### PR DESCRIPTION
## Issue Reference

This PR closes #324 by resolving clipping issues in `WidgetSetupView`. The content views were being clipped due to restrictive height constraints.

## Summary

- **Bug Fix**:
  - Removed the height constraint from the content view in `WidgetSetupView`.
  - While removing the constraint introduces ambiguity in the scrollable content, it ensures that all views are fully displayed without clipping.

- **Next Steps**:
  - Need to revisit the layout to ensure scrollable content works correctly without ambiguity and to implement a more robust solution for the view height management.