### PR TITLE
Fixed Auxiliary Widget Queries

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -446,6 +446,14 @@
 		B3F4EFB02CEF7B34006615BA /* IsStyleIncludedInPlusSpecification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F4EFA82CEF15E1006615BA /* IsStyleIncludedInPlusSpecification.swift */; };
 		B3F4EFB12CEF7B42006615BA /* PurchaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE15AB22CD97EFC000A255B /* PurchaseManager.swift */; };
 		B3F4EFB22CEF7BC6006615BA /* WidgetStylingProvider+PurchasedSkins.swift in Sources */ = {isa = PBXBuildFile; fileRef = B384D9402CE7A64700D17B93 /* WidgetStylingProvider+PurchasedSkins.swift */; };
+		B3F4EFBC2CEFD9E1006615BA /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F4EFBA2CEFD9E1006615BA /* LoadingViewController.swift */; };
+		B3F4EFBD2CEFDCA1006615BA /* SpaceGrotesk-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B32F3C042CD745C3000F4825 /* SpaceGrotesk-Regular.ttf */; };
+		B3F4EFBE2CEFDCA1006615BA /* SpaceGrotesk-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B32F3C052CD745C3000F4825 /* SpaceGrotesk-SemiBold.ttf */; };
+		B3F4EFBF2CEFDCA1006615BA /* ArchivoSemiCondensed-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B363B5692CE3907C002912CC /* ArchivoSemiCondensed-Bold.ttf */; };
+		B3F4EFC02CEFDCA1006615BA /* PixelOperator8-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B363B5652CE3907C002912CC /* PixelOperator8-Bold.ttf */; };
+		B3F4EFC12CEFDCA1006615BA /* SpaceGrotesk-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B32F3C032CD745C3000F4825 /* SpaceGrotesk-Medium.ttf */; };
+		B3F4EFC22CEFDCA1006615BA /* SpaceGrotesk-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B32F3C022CD745C3000F4825 /* SpaceGrotesk-Light.ttf */; };
+		B3F4EFC32CEFDCA1006615BA /* SpaceGrotesk-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B32F3C012CD745C3000F4825 /* SpaceGrotesk-Bold.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -936,11 +944,8 @@
 		B3F4EFA62CEF15C9006615BA /* HasPurchasedStyleSpecification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasPurchasedStyleSpecification.swift; sourceTree = "<group>"; };
 		B3F4EFA82CEF15E1006615BA /* IsStyleIncludedInPlusSpecification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsStyleIncludedInPlusSpecification.swift; sourceTree = "<group>"; };
 		B3F4EFAC2CEF79EC006615BA /* IsStyleAvailableSpecification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsStyleAvailableSpecification.swift; sourceTree = "<group>"; };
+		B3F4EFBA2CEFD9E1006615BA /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		B3F4EFB52CEFBF16006615BA /* ViewController */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ViewController; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		AF362C012CA5B1A300506443 /* Frameworks */ = {
@@ -3035,9 +3040,17 @@
 		B3F4EFB42CEFBF13006615BA /* Loading */ = {
 			isa = PBXGroup;
 			children = (
-				B3F4EFB52CEFBF16006615BA /* ViewController */,
+				B3F4EFBB2CEFD9E1006615BA /* ViewController */,
 			);
 			path = Loading;
+			sourceTree = "<group>";
+		};
+		B3F4EFBB2CEFD9E1006615BA /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				B3F4EFBA2CEFD9E1006615BA /* LoadingViewController.swift */,
+			);
+			path = ViewController;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -3171,9 +3184,6 @@
 				AFE5D5142CADD51600503572 /* PBXTargetDependency */,
 				AFE5D5262CADD52400503572 /* PBXTargetDependency */,
 				B39FB7E22CDAA51000967E3A /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				B3F4EFB52CEFBF16006615BA /* ViewController */,
 			);
 			name = Modulite;
 			packageProductDependencies = (
@@ -3361,6 +3371,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				AF0DB5232CD6DAA300451E18 /* TestModuliteIAP.storekit in Resources */,
+				B3F4EFBD2CEFDCA1006615BA /* SpaceGrotesk-Regular.ttf in Resources */,
+				B3F4EFBE2CEFDCA1006615BA /* SpaceGrotesk-SemiBold.ttf in Resources */,
+				B3F4EFBF2CEFDCA1006615BA /* ArchivoSemiCondensed-Bold.ttf in Resources */,
+				B3F4EFC02CEFDCA1006615BA /* PixelOperator8-Bold.ttf in Resources */,
+				B3F4EFC12CEFDCA1006615BA /* SpaceGrotesk-Medium.ttf in Resources */,
+				B3F4EFC22CEFDCA1006615BA /* SpaceGrotesk-Light.ttf in Resources */,
+				B3F4EFC32CEFDCA1006615BA /* SpaceGrotesk-Bold.ttf in Resources */,
 				B39A25E52CAFADF6001C76A5 /* BundleConfig.xcconfig in Resources */,
 				AFBBC50B2C7E459A00A9B256 /* Assets.xcassets in Resources */,
 			);
@@ -3711,6 +3728,7 @@
 				B34F3E142C6B93C80041D7BD /* HomeWidgetCollectionViewCell.swift in Sources */,
 				B32F3BA72CD2F2B1000F4825 /* WidgetSetupViewControllerDelegate.swift in Sources */,
 				B34C62FB2CD1847F004E014B /* OnboardingCoordinator.swift in Sources */,
+				B3F4EFBC2CEFD9E1006615BA /* LoadingViewController.swift in Sources */,
 				B3987E0D2CA38A8A00896414 /* MainWidget.swift in Sources */,
 				B3CDD7072C77C59B00E558F8 /* ImageProcessingFactory.swift in Sources */,
 				AF09AE862CD7102700E0707A /* GradientButton.swift in Sources */,

--- a/ModuliteWidget/Auxiliary/AuxWidgetProvider.swift
+++ b/ModuliteWidget/Auxiliary/AuxWidgetProvider.swift
@@ -14,6 +14,13 @@ struct AuxWidgetIntentProvider: AppIntentTimelineProvider {
     typealias Intent = SelectAuxWidgetConfigurationIntent
     typealias Entry = AuxWidgetEntry
     
+    init() {
+        Task {
+            await SubscriptionManager.shared.initialize()
+            WidgetCenter.shared.reloadTimelines(ofKind: "AuxWidget")
+        }   
+    }
+    
     func placeholder(in context: Context) -> AuxWidgetEntry {
         AuxWidgetEntry(date: .now, configuration: nil)
     }


### PR DESCRIPTION
## Issue Reference

This PR closes #342 by fixing a bug where widget queries were not functioning properly.

## Summary

- **Bug Fix**:
  - Corrected an issue where auxiliary widget queries were not working.
  - The problem was caused by inconsistent subscription status due to improper initialization of the subscription manager.
  
- **Solution**:
  - Updated the `IntentProvider` for auxiliary widgets to ensure that the subscription manager is loaded during initialization, thereby maintaining consistent subscription status throughout.