### PR TITLE
Fixed Retromac Dark Creation Forced Style

### DIFF
--- a/ModuliteWidget/Auxiliary/AuxWidgetProvider.swift
+++ b/ModuliteWidget/Auxiliary/AuxWidgetProvider.swift
@@ -18,7 +18,7 @@ struct AuxWidgetIntentProvider: AppIntentTimelineProvider {
         Task {
             await SubscriptionManager.shared.initialize()
             WidgetCenter.shared.reloadTimelines(ofKind: "AuxWidget")
-        }   
+        }
     }
     
     func placeholder(in context: Context) -> AuxWidgetEntry {

--- a/WidgetStyling/Models/Module/BaseModuleStyle.swift
+++ b/WidgetStyling/Models/Module/BaseModuleStyle.swift
@@ -149,11 +149,13 @@ public class BaseModuleStyle: ModuleStyle {
     
     public func imageWithForcedTraitIfNeeded() -> UIImage {
         guard let forcedStyle = forcedUserInterfaceStyle else { return image }
-        return image.withConfiguration(
-            UIImage.Configuration(
-                traitCollection: UITraitCollection(userInterfaceStyle: forcedStyle)
+        return image
+            .withConfiguration(
+                UIImage.Configuration(
+                    traitCollection: UITraitCollection(userInterfaceStyle: forcedStyle)
+                )
             )
-        )
+            .withRenderingMode(.alwaysOriginal)
     }
     
     private func applyShadow(to image: UIImage, shadowColor: UIColor) -> UIImage {
@@ -162,29 +164,24 @@ public class BaseModuleStyle: ModuleStyle {
         let shadowBlurRadius = self.shadowBlurRadius ?? 5.0
 
         let imageSize = image.size
-
-        // Cria um renderer com o tamanho original da imagem
+        
         let renderer = UIGraphicsImageRenderer(size: imageSize)
 
         let imageWithShadow = renderer.image { context in
             let cgContext = context.cgContext
-
-            // Salva o estado atual do contexto
+            
             cgContext.saveGState()
-
-            // Configura a sombra
+            
             cgContext.setShadow(
                 offset: shadowOffset,
                 blur: shadowBlurRadius,
                 color: shadowColor.withAlphaComponent(CGFloat(shadowOpacity)).cgColor
             )
-
-            // Desenha a imagem com a sombra
+            
             cgContext.beginTransparencyLayer(auxiliaryInfo: nil)
             image.draw(in: CGRect(origin: .zero, size: imageSize))
             cgContext.endTransparencyLayer()
-
-            // Restaura o estado do contexto
+            
             cgContext.restoreGState()
         }
 


### PR DESCRIPTION
## Issue Reference

This PR closes #344 by fixing a bug where RetromacDark images always appeared black.

## Summary

- **Bug Fix**:
  - Corrected an issue where the images for the RetromacDark widget style would always render in black, regardless of the app's light/dark mode settings.
  
- **Solution**:
  - Updated the rendering logic for the RetromacDark widget images to ensure the correct colors are applied based on the current user interface style.