### PR TITLE
Removed Paid Styles From Onboarding

### DIFF
--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewController/WidgetSetupViewController.swift
@@ -26,7 +26,13 @@ class WidgetSetupViewController: UIViewController {
     
     var didMakeChangesToWidget: Bool = false
     
-    var isOnboarding: Bool = false
+    var isOnboarding: Bool = false {
+        didSet {
+            if isOnboarding {
+                viewModel = WidgetSetupViewModel(isOnboarding: true)
+            }
+        }
+    }
     
     private var selectWidgetStyleTip = SelectWidgetStyleTip()
     private var selectAppsTip = SelectAppsTip()

--- a/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
+++ b/Modulite/Screens/WidgetConfiguration/Setup/ViewModel/WidgetSetupViewModel.swift
@@ -29,6 +29,15 @@ class WidgetSetupViewModel: NSObject {
     @Published private(set) var selectedStyle: WidgetStyle?
     @Published private(set) var selectedApps: [AppData] = []
     
+    // MARK: - Initializer
+    init(isOnboarding: Bool = false) {
+        super.init()
+        
+        if isOnboarding {
+            widgetStyles = widgetStyles.filter(\.isPurchased)
+        }
+    }
+    
     // MARK: - Getters
     func getIndexForSelectedStyle() -> Int? {
         guard let selectedStyle = selectedStyle else { return nil }


### PR DESCRIPTION
## Issue Reference

This PR closes #348 by removing paid widget styles from the onboarding flow.

## Summary

- **Enhancement**:
  - Updated the onboarding process to exclude paid widget styles, focusing only on free styles to simplify user experience during the initial app setup.
  - This helps avoid confusion for new users and allows them to become familiar with the available features without encountering paywalls.