### PR TITLE
Implemented Deep Link to Open Offer Plus

### DIFF
--- a/Modulite.xcodeproj/project.pbxproj
+++ b/Modulite.xcodeproj/project.pbxproj
@@ -380,6 +380,10 @@
 		B3A8BD6C2CF7BD90004F129E /* WebPresentingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A8BD6B2CF7BD90004F129E /* WebPresentingView.swift */; };
 		B3A8BD6E2CF7BD9A004F129E /* WebPresentingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A8BD6D2CF7BD9A004F129E /* WebPresentingViewController.swift */; };
 		B3AEF83B2CCA705C0019E91A /* AppBlockingSessionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AEF83A2CCA705C0019E91A /* AppBlockingSessionHeader.swift */; };
+		B3AF96552CF92CD100AB2277 /* HasCompletedOnboardingSpecification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF96542CF92CD100AB2277 /* HasCompletedOnboardingSpecification.swift */; };
+		B3AF96562CF92CD100AB2277 /* HasCompletedOnboardingSpecification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF96542CF92CD100AB2277 /* HasCompletedOnboardingSpecification.swift */; };
+		B3AF96582CF92D3A00AB2277 /* DidOpenWithEventSpecification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF96572CF92D3A00AB2277 /* DidOpenWithEventSpecification.swift */; };
+		B3AF96592CF92D3A00AB2277 /* DidOpenWithEventSpecification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF96572CF92D3A00AB2277 /* DidOpenWithEventSpecification.swift */; };
 		B3C6DD702CDE997F002AEAF7 /* PersistentAppData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C6DD6D2CDE997F002AEAF7 /* PersistentAppData+CoreDataClass.swift */; };
 		B3C6DD712CDE997F002AEAF7 /* PersistentAppData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C6DD6E2CDE997F002AEAF7 /* PersistentAppData+CoreDataProperties.swift */; };
 		B3C6DD722CDE997F002AEAF7 /* PersistentAppData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C6DD6D2CDE997F002AEAF7 /* PersistentAppData+CoreDataClass.swift */; };
@@ -908,6 +912,8 @@
 		B3A8BD6B2CF7BD90004F129E /* WebPresentingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPresentingView.swift; sourceTree = "<group>"; };
 		B3A8BD6D2CF7BD9A004F129E /* WebPresentingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPresentingViewController.swift; sourceTree = "<group>"; };
 		B3AEF83A2CCA705C0019E91A /* AppBlockingSessionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingSessionHeader.swift; sourceTree = "<group>"; };
+		B3AF96542CF92CD100AB2277 /* HasCompletedOnboardingSpecification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasCompletedOnboardingSpecification.swift; sourceTree = "<group>"; };
+		B3AF96572CF92D3A00AB2277 /* DidOpenWithEventSpecification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidOpenWithEventSpecification.swift; sourceTree = "<group>"; };
 		B3C6DD6D2CDE997F002AEAF7 /* PersistentAppData+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentAppData+CoreDataClass.swift"; sourceTree = "<group>"; };
 		B3C6DD6E2CDE997F002AEAF7 /* PersistentAppData+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentAppData+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B3C6DD782CDE9B28002AEAF7 /* AppData+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppData+Extensions.swift"; sourceTree = "<group>"; };
@@ -3092,6 +3098,8 @@
 				B3F4EFA62CEF15C9006615BA /* HasPurchasedStyleSpecification.swift */,
 				B3F4EFA82CEF15E1006615BA /* IsStyleIncludedInPlusSpecification.swift */,
 				B3F4EFAC2CEF79EC006615BA /* IsStyleAvailableSpecification.swift */,
+				B3AF96542CF92CD100AB2277 /* HasCompletedOnboardingSpecification.swift */,
+				B3AF96572CF92D3A00AB2277 /* DidOpenWithEventSpecification.swift */,
 			);
 			path = Specification;
 			sourceTree = "<group>";
@@ -3652,6 +3660,7 @@
 				B3987E2C2CA4F43100896414 /* SelectMainWidgetConfigurationIntent.swift in Sources */,
 				B3F4EF9F2CEF0EB4006615BA /* AuxWidgetView.swift in Sources */,
 				B3987E152CA38C7900896414 /* MainWidgetEntry.swift in Sources */,
+				B3AF96592CF92D3A00AB2277 /* DidOpenWithEventSpecification.swift in Sources */,
 				B3F4EF992CEF0E63006615BA /* AuxWidgetEntry.swift in Sources */,
 				B363B57F2CE3E20A002912CC /* MainWidgetStrategy.swift in Sources */,
 				B34C62E52CD16134004E014B /* AppListData.swift in Sources */,
@@ -3673,6 +3682,7 @@
 				B3F4EFB02CEF7B34006615BA /* IsStyleIncludedInPlusSpecification.swift in Sources */,
 				B363B5802CE3E214002912CC /* AuxWidgetStrategy.swift in Sources */,
 				B3F4EF8C2CEF0D6C006615BA /* AuxWidgetModuleData.swift in Sources */,
+				B3AF96552CF92CD100AB2277 /* HasCompletedOnboardingSpecification.swift in Sources */,
 				AF763F262CAF4492002FBE26 /* FamilyControlsManager.swift in Sources */,
 				B32B60F92C87AC81007DDCE3 /* FileManagerImagePersistenceController.swift in Sources */,
 				B3C6DD7F2CDE9B28002AEAF7 /* AppData+Extensions.swift in Sources */,
@@ -3812,6 +3822,7 @@
 				B34F3E3E2C74CE090041D7BD /* EditorSectionHeader.swift in Sources */,
 				B33808932CC2FFED00D56884 /* RequestScreenTimeViewController.swift in Sources */,
 				B3CB2C502CE56D7A009BADFB /* HomeViewController+HomeWidgetCollectionViewCellDelegate.swift in Sources */,
+				B3AF96562CF92CD100AB2277 /* HasCompletedOnboardingSpecification.swift in Sources */,
 				B35BFC522CB60B7300092B42 /* TutorialStepsStackView.swift in Sources */,
 				B3A8BD6E2CF7BD9A004F129E /* WebPresentingViewController.swift in Sources */,
 				B34F3DFD2C6A92890041D7BD /* RootTabBarController.swift in Sources */,
@@ -3858,6 +3869,7 @@
 				B35BFBEB2CB5B9D600092B42 /* TutorialCenterButtonLabel.swift in Sources */,
 				B35BFBCF2CB55F3F00092B42 /* SeparatorView.swift in Sources */,
 				B34F3E402C74E3270041D7BD /* WidgetModuleCell.swift in Sources */,
+				B3AF96582CF92D3A00AB2277 /* DidOpenWithEventSpecification.swift in Sources */,
 				B3F4EFA72CEF15C9006615BA /* HasPurchasedStyleSpecification.swift in Sources */,
 				B33808AC2CC31D8300D56884 /* RequestScreenTimeTexts.swift in Sources */,
 				B35BFB892CB4605C00092B42 /* TutorialMultiParagraphLabel.swift in Sources */,

--- a/Modulite/AppDelegate/SceneDelegate.swift
+++ b/Modulite/AppDelegate/SceneDelegate.swift
@@ -47,7 +47,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return false
         }
 
-        guard let host = url.host, host == "app" else {
+        guard let host = url.host else {
+            print("Unable to extract URL host.")
+            return false
+        }
+        
+        switch host {
+        case "app": break
+        case "plus":
+            registerShouldPresentOfferPlus()
+            return true
+        default:
             print("Invalid URL host: \(url.host ?? "nil")")
             return false
         }
@@ -83,6 +93,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         } else {
             print("Invalid URL for scheme: \(urlScheme)")
         }
+    }
+    
+    private func registerShouldPresentOfferPlus() {
+        UserDefaults.standard.set(true, forKey: "shouldPresentOfferPlus")
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Modulite/Coordinators/Home/HomeCoordinator.swift
+++ b/Modulite/Coordinators/Home/HomeCoordinator.swift
@@ -102,6 +102,15 @@ extension HomeCoordinator: HomeViewControllerDelegate {
         presentChild(coordinator, animated: true)
     }
     
+    func homeViewController(
+        _ viewController: HomeViewController,
+        shouldPresentOfferPlus: Bool
+    ) {
+        guard shouldPresentOfferPlus else { return }
+        
+        presentPlusModal(in: viewController)
+    }
+    
     private func presentPlusModal(in viewController: UIViewController) {
         let router = ModalNavigationRouter(
             parentViewController: viewController,

--- a/Modulite/Screens/Home/ViewController/HomeViewController.swift
+++ b/Modulite/Screens/Home/ViewController/HomeViewController.swift
@@ -23,6 +23,11 @@ protocol HomeViewControllerDelegate: AnyObject {
     func homeViewControllerDidFinishOnboarding(
         _ viewController: HomeViewController
     )
+    
+    func homeViewController(
+        _ viewController: HomeViewController,
+        shouldPresentOfferPlus: Bool
+    )
 }
 
 class HomeViewController: UIViewController {
@@ -50,6 +55,12 @@ class HomeViewController: UIViewController {
         updatePlaceholderViews()
         setupOnboardingObserverIfNeeded()
         setupSubscriptions()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        checkIfDidShouldPresentPlus()
     }
     
     deinit {
@@ -90,6 +101,18 @@ class HomeViewController: UIViewController {
     }
     
     // MARK: - Actions
+    private func checkIfDidShouldPresentPlus() {
+        let spec = HasCompletedOnboardingSpecification()
+                       .and(DidOpenWithEventSpecification())
+        
+        delegate?.homeViewController(
+            self,
+            shouldPresentOfferPlus: spec.isSatisfied()
+        )
+        
+        UserDefaults.standard.set(false, forKey: "shouldPresentOfferPlus")
+    }
+    
     @objc private func handleOnboardingCompletion() {
         delegate?.homeViewControllerDidFinishOnboarding(self)
         

--- a/Modulite/Specification/DidOpenWithEventSpecification.swift
+++ b/Modulite/Specification/DidOpenWithEventSpecification.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct DidOpenWithEventSpecification: Specification {
+    func isSatisfied() -> Bool {
+        UserDefaults.standard.bool(forKey: "shouldPresentOfferPlus")
+    }
+}

--- a/Modulite/Specification/DidOpenWithEventSpecification.swift
+++ b/Modulite/Specification/DidOpenWithEventSpecification.swift
@@ -1,0 +1,8 @@
+//
+//  DidOpenWithEventSpecification.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 28/11/24.
+//
+
+import Foundation

--- a/Modulite/Specification/HasCompletedOnboardingSpecification.swift
+++ b/Modulite/Specification/HasCompletedOnboardingSpecification.swift
@@ -1,0 +1,8 @@
+//
+//  HasCompletedOnboardingSpecification.swift
+//  Modulite
+//
+//  Created by Gustavo Munhoz Correa on 28/11/24.
+//
+
+import Foundation

--- a/Modulite/Specification/HasCompletedOnboardingSpecification.swift
+++ b/Modulite/Specification/HasCompletedOnboardingSpecification.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct HasCompletedOnboardingSpecification: Specification {
+    func isSatisfied() -> Bool {
+        UserPreference<Onboarding>.shared.bool(for: .hasCompletedOnboarding)
+    }
+}


### PR DESCRIPTION
## Issue Reference

This PR closes #355 by implementing a deep link for the in-app event, which directs users to the "Plus" section using the link `moduliteapp://plus`.

## Summary

- Added support for deep linking to handle incoming links starting with `moduliteapp://plus`.
- Implemented routing logic to navigate directly to the Plus section when the app is opened via an in-app event.
- Ensured proper handling and user experience for existing users and new users who may arrive through this link.